### PR TITLE
Fix stock validation and dashboard logic

### DIFF
--- a/V4-App Gestion Stocks.html
+++ b/V4-App Gestion Stocks.html
@@ -541,7 +541,7 @@
             
             <div class="sempa-form-group">
                 <label class="sempa-label">Quantité (cartons)</label>
-                <input type="number" id="movement-quantity" class="sempa-input" min="1" value="1">
+                <input type="number" id="movement-quantity" class="sempa-input" min="0" value="1">
             </div>
             
             <div class="sempa-form-group">
@@ -793,13 +793,22 @@
             sortedMovements.forEach(movement => {
                 const product = products.find(p => p.id === movement.productId);
                 if (!product) return;
-                
+
+                const movementDate = new Date(movement.date);
+                const formattedDate = Number.isNaN(movementDate.getTime()) ? '' : movementDate.toLocaleDateString('fr-FR');
+                const typeLabel = movement.type === 'in' ? 'Entrée' : movement.type === 'out' ? 'Sortie' : 'Ajustement';
+                const quantityDisplay = movement.type === 'in'
+                    ? `+${movement.quantity}`
+                    : movement.type === 'out'
+                        ? `-${movement.quantity}`
+                        : `=${movement.quantity}`;
+
                 const row = document.createElement('tr');
                 row.innerHTML = `
-                    <td>${new Date(movement.date).toLocaleDateString('fr-FR')}</td>
+                    <td>${formattedDate}</td>
                     <td>${product.name}</td>
-                    <td>${movement.type === 'in' ? 'Entrée' : movement.type === 'out' ? 'Sortie' : 'Ajustement'}</td>
-                    <td>${movement.type === 'in' ? '+' : '-'}${movement.quantity}</td>
+                    <td>${typeLabel}</td>
+                    <td>${quantityDisplay}</td>
                     <td>${movement.reason}</td>
                 `;
                 table.appendChild(row);
@@ -810,8 +819,12 @@
         function updateDashboard() {
             // Calculer les statistiques
             const totalProducts = products.length;
-            const lowStockCount = products.filter(p => p.stock <= p.minStock).length;
-            const totalCartons = products.reduce((sum, p) => sum + p.stock, 0);
+            const lowStockProducts = products.filter(p => getStockStatus(p.stock, p.minStock) === 'low');
+            const lowStockCount = lowStockProducts.length;
+            const totalCartons = products.reduce((sum, p) => {
+                const stockValue = Number(p.stock);
+                return Number.isFinite(stockValue) ? sum + stockValue : sum;
+            }, 0);
             
             // Mettre à jour les valeurs
             const totalProductsEl = document.getElementById('total-products');
@@ -828,8 +841,7 @@
             const alertsContainer = document.getElementById('alerts-container');
             if (alertsContainer) {
                 alertsContainer.innerHTML = '';
-                
-                const lowStockProducts = products.filter(p => p.stock <= p.minStock);
+
                 if (lowStockProducts.length > 0) {
                     const alertDiv = document.createElement('div');
                     alertDiv.className = 'sempa-alert';
@@ -852,8 +864,17 @@
         
         // Obtenir le statut du stock
         function getStockStatus(stock, minStock) {
-            if (stock <= minStock * 0.3) return 'low';
-            if (stock <= minStock) return 'medium';
+            const parsedStock = Number(stock);
+            const parsedMinStock = Number(minStock);
+            const stockValue = Number.isFinite(parsedStock) ? parsedStock : 0;
+            const minStockValue = Number.isFinite(parsedMinStock) ? parsedMinStock : 0;
+
+            if (minStockValue <= 0) {
+                return stockValue > 0 ? 'good' : 'low';
+            }
+
+            if (stockValue <= minStockValue * 0.3) return 'low';
+            if (stockValue <= minStockValue) return 'medium';
             return 'good';
         }
         
@@ -923,18 +944,39 @@
         
         // Sauvegarder un produit
         function saveProduct() {
-            const name = document.getElementById('product-name').value;
-            const reference = document.getElementById('product-ref').value;
-            const stock = parseInt(document.getElementById('product-stock').value);
-            const minStock = parseInt(document.getElementById('product-minstock').value);
-            const price = parseFloat(document.getElementById('product-price').value);
+            const name = document.getElementById('product-name').value.trim();
+            const reference = document.getElementById('product-ref').value.trim();
+            const stockInput = Number.parseInt(document.getElementById('product-stock').value, 10);
+            const minStockInput = Number.parseInt(document.getElementById('product-minstock').value, 10);
+            let priceInput = Number.parseFloat(document.getElementById('product-price').value);
             const category = document.getElementById('product-category').value;
-            const description = document.getElementById('product-desc').value;
-            
+            const description = document.getElementById('product-desc').value.trim();
+
             if (!name || !reference) {
                 alert('Veuillez remplir au moins le nom et la référence du produit');
                 return;
             }
+
+            if (!Number.isFinite(stockInput) || stockInput < 0) {
+                alert('Veuillez saisir un stock valide (0 ou plus).');
+                return;
+            }
+
+            if (!Number.isFinite(minStockInput) || minStockInput <= 0) {
+                alert("Veuillez saisir un seuil d'alerte valide (supérieur à 0).");
+                return;
+            }
+
+            if (!Number.isFinite(priceInput)) {
+                priceInput = 0;
+            } else if (priceInput < 0) {
+                alert('Veuillez saisir un prix unitaire positif.');
+                return;
+            }
+
+            const stock = stockInput;
+            const minStock = minStockInput;
+            const price = Math.round(priceInput * 100) / 100;
             
             if (currentProductId) {
                 // Modification d'un produit existant
@@ -980,13 +1022,28 @@
         function addStockMovement() {
             const productId = document.getElementById('movement-product').value;
             const type = document.getElementById('movement-type').value;
-            const quantity = parseInt(document.getElementById('movement-quantity').value);
-            const reason = document.getElementById('movement-reason').value;
-            
-            if (!productId || isNaN(quantity) || quantity <= 0 || !reason) {
-                alert('Veuillez remplir tous les champs correctement');
+            const quantityInput = Number.parseInt(document.getElementById('movement-quantity').value, 10);
+            const reason = document.getElementById('movement-reason').value.trim();
+
+            if (!productId) {
+                alert('Veuillez sélectionner un produit.');
                 return;
             }
+
+            const quantityIsInvalid = !Number.isFinite(quantityInput) ||
+                (type === 'adjust' ? quantityInput < 0 : quantityInput <= 0);
+
+            if (quantityIsInvalid) {
+                alert("Veuillez saisir une quantité valide.");
+                return;
+            }
+
+            if (!reason) {
+                alert('Veuillez indiquer une raison.');
+                return;
+            }
+
+            const quantity = quantityInput;
             
             const productIndex = products.findIndex(p => p.id === productId);
             if (productIndex === -1) {


### PR DESCRIPTION
## Summary
- strengthen product form validation by trimming values, rejecting invalid numbers, and normalising stored prices
- allow zero-quantity adjustments, trim movement reasons, and display clear movement quantities in the history
- refresh dashboard metrics and stock status calculations to rely on safe numeric values and accurately count low-stock alerts

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cd365e2b5c832f9342141aa443e158