### PR TITLE
fix: nettoyer la clôture du script d'inventaire

### DIFF
--- a/V2-Appli-Inventaire.html
+++ b/V2-Appli-Inventaire.html
@@ -929,24 +929,4 @@
         });
     </script>
 </body>
-</html>;
-
-        elements.markAvailable.addEventListener('click', () => {
-            const id = elements.saleItemId.value;
-            updateItem(id, {
-                vendu: false,
-                prixVente: null,
-                dateVente: '',
-                plateforme: ''
-            });
-            closeSaleModal();
-        });
-
-        document.addEventListener('DOMContentLoaded', async () => {
-            loadItems();
-            render();
-            await loadMobilenet();
-        });
-    </script>
-</body>
 </html>


### PR DESCRIPTION
## Summary
- remove the duplicate closing script block accidentally appended after the HTML footer
- ensure the V2 inventory page now ends with a single valid </html> tag without stray characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8fdd168c832f9ad136e0ac4b353a