### PR TITLE
Remove header logo from V4 stock page

### DIFF
--- a/V4-App Gestion Stocks.html
+++ b/V4-App Gestion Stocks.html
@@ -115,19 +115,6 @@
             gap: 16px;
         }
 
-        .brand-mark {
-            width: 52px;
-            height: 52px;
-            border-radius: 16px;
-            background: linear-gradient(135deg, var(--primary), rgba(255, 197, 109, 0.85));
-            color: #fff;
-            font-weight: 700;
-            display: grid;
-            place-items: center;
-            letter-spacing: 0.08em;
-            box-shadow: 0 18px 32px rgba(255, 159, 28, 0.35);
-        }
-
         .brand h1 {
             font-size: clamp(1.5rem, 2vw, 2.2rem);
             letter-spacing: -0.02em;
@@ -837,7 +824,6 @@
         <header class="app-header">
             <div class="header-inner">
                 <div class="brand">
-                    <div class="brand-mark">SE</div>
                     <div>
                         <h1>Gestion des Stocks SEMPA</h1>
                         <p>Visualisez et ajustez vos stocks instantanément, même en mobilité.</p>


### PR DESCRIPTION
## Summary
- remove the SEMPA logo block from the header of the V4 stock management page
- clean up the related CSS styling for the deleted logo element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcfb247e0832f943f9dc6b66c3df7