### PR TITLE
Remove unused SEO title handling from Inventaire Bijoux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# sempa
-Codage
+# Inventaire Bijoux
+
+Application web de suivi d'inventaire spécialisée pour les bijoux, dérivée de l'interface V9 existante.
+
+## Fichiers principaux
+
+- `inventaire-bijoux.html` : interface web mobile-first (FR) avec génération automatique de titres, gestion de stock et historiques.
+- `api/bijoux.php` : API REST (token `inventaire-bijoux-token`) gérant CRUD, opérations de stock, import/export CSV et historiques.
+
+## Lancement
+
+Ouvrir `inventaire-bijoux.html` dans un navigateur. L'API PHP lit/écrit ses données dans `api/data/bijoux.json`.

--- a/api/bijoux.php
+++ b/api/bijoux.php
@@ -1,0 +1,671 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Auth-Token, X-User');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+const DATA_FILE = __DIR__ . '/data/bijoux.json';
+const AUTH_TOKEN = 'inventaire-bijoux-token';
+
+function getAuthorizationToken(): string
+{
+    $headers = getallheaders();
+    $auth = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+    if ($auth !== '') {
+        if (stripos($auth, 'Bearer ') === 0) {
+            return trim(substr($auth, 7));
+        }
+        return trim($auth);
+    }
+    return $headers['X-Auth-Token'] ?? $headers['x-auth-token'] ?? '';
+}
+
+function ensureAuthorized(): void
+{
+    $token = getAuthorizationToken();
+    if ($token !== AUTH_TOKEN) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Accès non autorisé.']);
+        exit;
+    }
+}
+
+function respond(array $data, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+    exit;
+}
+
+function errorResponse(string $message, int $status = 400): void
+{
+    respond(['error' => $message], $status);
+}
+
+function ensureDataDirectory(): void
+{
+    $directory = dirname(DATA_FILE);
+    if (!is_dir($directory)) {
+        if (!mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Impossible de créer le répertoire de données.');
+        }
+    }
+}
+
+function decodeData(?string $contents): array
+{
+    if ($contents === false || trim((string) $contents) === '') {
+        return [
+            'bijoux' => [],
+            'logs' => [],
+            'titres' => [],
+        ];
+    }
+    $decoded = json_decode($contents, true);
+    if (!is_array($decoded)) {
+        return [
+            'bijoux' => [],
+            'logs' => [],
+            'titres' => [],
+        ];
+    }
+    $decoded['bijoux'] = array_values(array_filter($decoded['bijoux'] ?? [], 'is_array'));
+    $decoded['logs'] = array_values(array_filter($decoded['logs'] ?? [], 'is_array'));
+    $decoded['titres'] = array_values(array_filter($decoded['titres'] ?? [], 'is_array'));
+    return $decoded;
+}
+
+function loadData(): array
+{
+    ensureDataDirectory();
+    $handle = fopen(DATA_FILE, 'c+');
+    if ($handle === false) {
+        throw new RuntimeException('Impossible d\'ouvrir le fichier de données.');
+    }
+    if (!flock($handle, LOCK_SH)) {
+        fclose($handle);
+        throw new RuntimeException('Impossible de verrouiller le fichier de données.');
+    }
+    rewind($handle);
+    $contents = stream_get_contents($handle);
+    flock($handle, LOCK_UN);
+    fclose($handle);
+    return decodeData($contents);
+}
+
+function withData(callable $callback)
+{
+    ensureDataDirectory();
+    $handle = fopen(DATA_FILE, 'c+');
+    if ($handle === false) {
+        throw new RuntimeException('Impossible d\'ouvrir le fichier de données.');
+    }
+    if (!flock($handle, LOCK_EX)) {
+        fclose($handle);
+        throw new RuntimeException('Impossible de verrouiller le fichier de données.');
+    }
+    rewind($handle);
+    $contents = stream_get_contents($handle);
+    $data = decodeData($contents);
+    $response = $callback($data);
+    $encoded = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+    if ($encoded === false) {
+        flock($handle, LOCK_UN);
+        fclose($handle);
+        throw new RuntimeException('Impossible d\'encoder les données.');
+    }
+    rewind($handle);
+    ftruncate($handle, 0);
+    fwrite($handle, $encoded . PHP_EOL);
+    fflush($handle);
+    flock($handle, LOCK_UN);
+    fclose($handle);
+    return $response;
+}
+
+function decodeJsonBody(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || trim($raw) === '') {
+        return [];
+    }
+    $decoded = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($decoded)) {
+        throw new InvalidArgumentException('Corps de requête JSON invalide.');
+    }
+    return $decoded;
+}
+
+function sanitizeString(mixed $value): string
+{
+    return trim((string) ($value ?? ''));
+}
+
+function sanitizeInt(mixed $value, bool $allowZero = true): int
+{
+    if ($value === null || $value === '') {
+        if ($allowZero) {
+            return 0;
+        }
+        throw new InvalidArgumentException('Valeur entière requise.');
+    }
+    $filtered = filter_var($value, FILTER_VALIDATE_INT);
+    if ($filtered === false) {
+        throw new InvalidArgumentException('Valeur entière invalide.');
+    }
+    if (!$allowZero && $filtered <= 0) {
+        throw new InvalidArgumentException('La valeur doit être supérieure à zéro.');
+    }
+    if ($filtered < 0) {
+        throw new InvalidArgumentException('La valeur ne peut pas être négative.');
+    }
+    return $filtered;
+}
+
+function sanitizeFloat(mixed $value): ?float
+{
+    if ($value === null || $value === '') {
+        return null;
+    }
+    $filtered = filter_var($value, FILTER_VALIDATE_FLOAT);
+    if ($filtered === false || $filtered < 0) {
+        throw new InvalidArgumentException('Valeur numérique invalide.');
+    }
+    return round((float) $filtered, 2);
+}
+
+function currentIsoDate(): string
+{
+    return date('c');
+}
+
+function getUser(): string
+{
+    $headers = getallheaders();
+    $user = $headers['X-User'] ?? $headers['x-user'] ?? 'système';
+    $user = trim((string) $user);
+    return $user !== '' ? $user : 'système';
+}
+
+function normalizePhotos(mixed $value): array
+{
+    if (is_array($value)) {
+        return array_values(array_filter(array_map('sanitizeString', $value), static fn ($item) => $item !== ''));
+    }
+    $single = sanitizeString($value ?? '');
+    return $single === '' ? [] : [$single];
+}
+
+function validateBijou(array $payload, bool $isCreation = false): array
+{
+    $id = sanitizeString($payload['id'] ?? '');
+    if ($id === '' && $isCreation) {
+        $id = uniqid('b_', true);
+    }
+    if ($id === '') {
+        throw new InvalidArgumentException('Identifiant du bijou requis.');
+    }
+
+    $type = sanitizeString($payload['type'] ?? '');
+    $typeAllowed = ['collier', 'boucles', 'bracelet'];
+    if (!in_array($type, $typeAllowed, true)) {
+        throw new InvalidArgumentException('Type de bijou invalide.');
+    }
+
+    $matiere = sanitizeString($payload['matiere'] ?? '');
+    if ($matiere === '') {
+        throw new InvalidArgumentException('La matière est obligatoire.');
+    }
+
+    $caracteristique = sanitizeString($payload['caracteristique'] ?? '');
+    if ($caracteristique === '') {
+        throw new InvalidArgumentException('La caractéristique principale est obligatoire.');
+    }
+
+    $dimensions = sanitizeString($payload['dimensions'] ?? '');
+    if ($dimensions === '') {
+        throw new InvalidArgumentException('Les dimensions sont obligatoires.');
+    }
+
+    $couleur = sanitizeString($payload['couleur'] ?? '');
+    $couleurs = sanitizeString($payload['couleurs'] ?? '');
+
+    $quantite = sanitizeInt($payload['quantite'] ?? 0);
+    $seuilBas = sanitizeInt($payload['seuil_bas'] ?? 0);
+    $prixAchat = sanitizeFloat($payload['prix_achat'] ?? null);
+    $flag = (bool) ($payload['flag_a_renseigner'] ?? false);
+
+    $photos = normalizePhotos($payload['photos'] ?? []);
+    $marque = sanitizeString($payload['marque'] ?? '');
+    $etat = sanitizeString($payload['etat'] ?? '');
+    $defauts = sanitizeString($payload['defauts'] ?? '');
+
+    $titreCourt = sanitizeString($payload['titre_court'] ?? '');
+    $titreAvertissement = (bool) ($payload['titre_avertissement'] ?? false);
+
+    return [
+        'id' => $id,
+        'type' => $type,
+        'photos' => $photos,
+        'couleur' => $couleur,
+        'couleurs' => $couleurs,
+        'matiere' => $matiere,
+        'caracteristique' => $caracteristique,
+        'dimensions' => $dimensions,
+        'quantite' => $quantite,
+        'seuil_bas' => $seuilBas,
+        'prix_achat' => $prixAchat,
+        'flag_a_renseigner' => $flag,
+        'titre_court' => $titreCourt,
+        'titre_avertissement' => $titreAvertissement,
+        'marque' => $marque,
+        'etat' => $etat,
+        'defauts' => $defauts,
+        'created_at' => sanitizeString($payload['created_at'] ?? '') ?: currentIsoDate(),
+        'updated_at' => currentIsoDate(),
+    ];
+}
+
+function buildTitleHistory(string $bijouId, string $user, string $field, string $ancienneValeur, string $nouvelleValeur): array
+{
+    return [
+        'id' => uniqid('t_', true),
+        'bijou_id' => $bijouId,
+        'champ' => $field,
+        'ancienne_valeur' => $ancienneValeur,
+        'nouvelle_valeur' => $nouvelleValeur,
+        'utilisateur' => $user,
+        'timestamp' => currentIsoDate(),
+    ];
+}
+
+function buildLog(string $bijouId, string $action, int $delta, int $nouvelleQuantite, string $user, array $extra = []): array
+{
+    return array_merge([
+        'id' => uniqid('l_', true),
+        'bijou_id' => $bijouId,
+        'action' => $action,
+        'delta' => $delta,
+        'nouvelle_quantite' => $nouvelleQuantite,
+        'utilisateur' => $user,
+        'timestamp' => currentIsoDate(),
+    ], $extra);
+}
+
+function applyStockOperation(array &$bijou, string $action, int $valeur, string $user, array &$logs): array
+{
+    if ($valeur <= 0 && $action !== 'set') {
+        throw new InvalidArgumentException('La quantité doit être supérieure à zéro.');
+    }
+    $quantiteActuelle = $bijou['quantite'];
+    $nouvelleQuantite = $quantiteActuelle;
+    $delta = 0;
+
+    switch ($action) {
+        case 'add':
+            $nouvelleQuantite += $valeur;
+            $delta = $valeur;
+            break;
+        case 'remove':
+        case 'sold':
+        case 'reserve':
+            if ($quantiteActuelle - $valeur < 0) {
+                throw new InvalidArgumentException('Stock insuffisant.');
+            }
+            $nouvelleQuantite -= $valeur;
+            $delta = -$valeur;
+            break;
+        case 'set':
+            if ($valeur < 0) {
+                throw new InvalidArgumentException('La quantité ne peut pas être négative.');
+            }
+            $delta = $valeur - $quantiteActuelle;
+            $nouvelleQuantite = $valeur;
+            break;
+        default:
+            throw new InvalidArgumentException('Action de stock inconnue.');
+    }
+
+    $bijou['quantite'] = $nouvelleQuantite;
+    $bijou['updated_at'] = currentIsoDate();
+
+    $logs[] = buildLog($bijou['id'], $action, $delta, $nouvelleQuantite, $user, ['valeur' => $valeur]);
+
+    return ['bijou' => $bijou];
+}
+
+function extractPrimaryDimension(string $dimensions): string
+{
+    if ($dimensions === '') {
+        return '';
+    }
+    $parts = preg_split('/[,\/]/', $dimensions);
+    if ($parts === false || count($parts) === 0) {
+        return trim($dimensions);
+    }
+    $first = trim($parts[0]);
+    return $first !== '' ? $first : trim($dimensions);
+}
+
+function generateTitles(string $type, string $matiere, string $caracteristique, string $dimensions): array
+{
+    $typeTitre = ucfirst($type);
+    $matiereTitre = trim($matiere);
+    $caracTitre = trim($caracteristique);
+    $dimensionPrincipale = extractPrimaryDimension($dimensions);
+
+    if ($typeTitre === '' || $matiereTitre === '' || $caracTitre === '' || $dimensionPrincipale === '') {
+        return [
+            'titre_court' => '',
+            'avertissement' => true,
+        ];
+    }
+
+    $titreCourt = sprintf('%s %s %s %s', $typeTitre, $matiereTitre, $caracTitre, $dimensionPrincipale);
+
+    return [
+        'titre_court' => trim(preg_replace('/\s+/', ' ', $titreCourt)),
+        'avertissement' => false,
+    ];
+}
+
+function handleCsvImport(array $fileData, string $user): array
+{
+    if (!isset($fileData['tmp_name']) || !is_uploaded_file($fileData['tmp_name'])) {
+        throw new InvalidArgumentException('Fichier CSV manquant.');
+    }
+    $handle = fopen($fileData['tmp_name'], 'r');
+    if ($handle === false) {
+        throw new RuntimeException('Impossible d\'ouvrir le fichier CSV.');
+    }
+    $header = fgetcsv($handle, 0, ';');
+    if ($header === false) {
+        fclose($handle);
+        throw new InvalidArgumentException('CSV vide.');
+    }
+    $header = array_map('mb_strtolower', $header);
+    $required = ['type', 'matiere', 'caracteristique', 'dimensions', 'quantite'];
+    foreach ($required as $column) {
+        if (!in_array($column, $header, true)) {
+            fclose($handle);
+            throw new InvalidArgumentException('Colonne requise manquante: ' . $column);
+        }
+    }
+    $results = ['crees' => 0, 'mis_a_jour' => 0];
+
+    withData(function (array &$data) use ($handle, $header, &$results, $user) {
+        while (($row = fgetcsv($handle, 0, ';')) !== false) {
+            if (count($row) === 1 && trim((string) $row[0]) === '') {
+                continue;
+            }
+            $assoc = [];
+            foreach ($header as $index => $col) {
+                $assoc[$col] = $row[$index] ?? '';
+            }
+            $quantite = sanitizeInt($assoc['quantite'] ?? 0);
+            $seuilBas = isset($assoc['seuil_bas']) ? sanitizeInt($assoc['seuil_bas'], true) : 0;
+            $prix = isset($assoc['prix_achat']) ? sanitizeFloat($assoc['prix_achat']) : null;
+
+            $titre = sanitizeString($assoc['titre'] ?? '');
+            $gen = generateTitles(
+                sanitizeString($assoc['type'] ?? ''),
+                sanitizeString($assoc['matiere'] ?? ''),
+                sanitizeString($assoc['caracteristique'] ?? ''),
+                sanitizeString($assoc['dimensions'] ?? '')
+            );
+            if ($titre === '') {
+                $titre = $gen['titre_court'];
+            }
+
+            $bijou = [
+                'id' => $assoc['id'] ?? uniqid('b_', true),
+                'type' => sanitizeString($assoc['type'] ?? ''),
+                'photos' => [],
+                'couleur' => sanitizeString($assoc['couleur'] ?? ''),
+                'couleurs' => sanitizeString($assoc['couleurs'] ?? ''),
+                'matiere' => sanitizeString($assoc['matiere'] ?? ''),
+                'caracteristique' => sanitizeString($assoc['caracteristique'] ?? ''),
+                'dimensions' => sanitizeString($assoc['dimensions'] ?? ''),
+                'quantite' => $quantite,
+                'seuil_bas' => $seuilBas,
+                'prix_achat' => $prix,
+                'flag_a_renseigner' => (bool) ($assoc['flag_a_renseigner'] ?? false),
+                'titre_court' => $titre,
+                'titre_avertissement' => $gen['avertissement'],
+                'marque' => sanitizeString($assoc['marque'] ?? ''),
+                'etat' => sanitizeString($assoc['etat'] ?? ''),
+                'defauts' => sanitizeString($assoc['defauts'] ?? ''),
+                'created_at' => currentIsoDate(),
+                'updated_at' => currentIsoDate(),
+            ];
+
+            $existingKey = null;
+            foreach ($data['bijoux'] as $index => $existing) {
+                if (($existing['id'] ?? '') === $bijou['id']) {
+                    $existingKey = $index;
+                    break;
+                }
+            }
+
+            if ($existingKey === null) {
+                $data['bijoux'][] = $bijou;
+                $data['logs'][] = buildLog($bijou['id'], 'set', $bijou['quantite'], $bijou['quantite'], $user, ['via' => 'import']);
+                $results['crees']++;
+            } else {
+                $delta = $bijou['quantite'] - ($data['bijoux'][$existingKey]['quantite'] ?? 0);
+                $data['bijoux'][$existingKey] = $bijou;
+                $data['logs'][] = buildLog($bijou['id'], 'set', $delta, $bijou['quantite'], $user, ['via' => 'import']);
+                $results['mis_a_jour']++;
+            }
+        }
+        fclose($handle);
+        return $results;
+    });
+
+    return $results;
+}
+
+function handleCsvExport(array $data): void
+{
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="inventaire_bijoux.csv"');
+    $output = fopen('php://output', 'w');
+    $header = [
+        'id',
+        'type',
+        'titre',
+        'matiere',
+        'caracteristique',
+        'dimensions',
+        'couleur',
+        'couleurs',
+        'marque',
+        'etat',
+        'defauts',
+        'quantite',
+        'seuil_bas',
+        'prix_achat',
+        'flag_a_renseigner',
+    ];
+    fputcsv($output, $header, ';');
+    foreach ($data['bijoux'] as $bijou) {
+        fputcsv($output, [
+            $bijou['id'] ?? '',
+            $bijou['type'] ?? '',
+            $bijou['titre_court'] ?? '',
+            $bijou['matiere'] ?? '',
+            $bijou['caracteristique'] ?? '',
+            $bijou['dimensions'] ?? '',
+            $bijou['couleur'] ?? '',
+            $bijou['couleurs'] ?? '',
+            $bijou['marque'] ?? '',
+            $bijou['etat'] ?? '',
+            $bijou['defauts'] ?? '',
+            $bijou['quantite'] ?? 0,
+            $bijou['seuil_bas'] ?? 0,
+            $bijou['prix_achat'] ?? '',
+            $bijou['flag_a_renseigner'] ? '1' : '0',
+        ], ';');
+    }
+    fclose($output);
+    exit;
+}
+
+try {
+    ensureAuthorized();
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+    $resource = sanitizeString($_GET['resource'] ?? '');
+    $id = isset($_GET['id']) ? sanitizeString($_GET['id']) : null;
+    $action = sanitizeString($_GET['action'] ?? '');
+    $user = getUser();
+
+    if ($method === 'GET' && $resource === 'export') {
+        $data = loadData();
+        handleCsvExport($data);
+    }
+
+    switch ($method) {
+        case 'GET':
+            $data = loadData();
+            if ($resource === 'bijoux') {
+                if ($id) {
+                    foreach ($data['bijoux'] as $bijou) {
+                        if (($bijou['id'] ?? '') === $id) {
+                            respond(['bijou' => $bijou]);
+                        }
+                    }
+                    errorResponse('Bijou introuvable.', 404);
+                }
+                respond(['bijoux' => $data['bijoux']]);
+            }
+            if ($resource === 'historique') {
+                $bijouId = sanitizeString($_GET['bijou_id'] ?? '');
+                $page = max(1, (int) ($_GET['page'] ?? 1));
+                $perPage = max(1, (int) ($_GET['per_page'] ?? 10));
+                $logs = array_values(array_filter($data['logs'], static fn ($log) => $bijouId === '' || ($log['bijou_id'] ?? '') === $bijouId));
+                $total = count($logs);
+                $offset = ($page - 1) * $perPage;
+                $items = array_slice($logs, $offset, $perPage);
+                respond([
+                    'logs' => $items,
+                    'pagination' => [
+                        'page' => $page,
+                        'per_page' => $perPage,
+                        'total' => $total,
+                    ],
+                ]);
+            }
+            if ($resource === 'titres') {
+                $bijouId = sanitizeString($_GET['bijou_id'] ?? '');
+                $history = array_values(array_filter($data['titres'], static fn ($entry) => $bijouId === '' || ($entry['bijou_id'] ?? '') === $bijouId));
+                respond(['titres' => $history]);
+            }
+            respond($data);
+
+        case 'POST':
+            if ($resource === 'bijoux') {
+                $payload = decodeJsonBody();
+                $bijou = validateBijou($payload, true);
+                $titles = generateTitles($bijou['type'], $bijou['matiere'], $bijou['caracteristique'], $bijou['dimensions']);
+                if ($bijou['titre_court'] === '') {
+                    $bijou['titre_court'] = $titles['titre_court'];
+                }
+                $bijou['titre_avertissement'] = $titles['avertissement'];
+
+                $result = withData(function (array &$data) use ($bijou, $user) {
+                    foreach ($data['bijoux'] as $existing) {
+                        if (($existing['id'] ?? '') === $bijou['id']) {
+                            throw new RuntimeException('Un bijou avec cet identifiant existe déjà.', 409);
+                        }
+                    }
+                    $data['bijoux'][] = $bijou;
+                    $data['logs'][] = buildLog($bijou['id'], 'set', $bijou['quantite'], $bijou['quantite'], $user, ['via' => 'creation']);
+                    return ['bijou' => $bijou];
+                });
+                respond($result, 201);
+            }
+
+            if ($resource === 'stock' && $id) {
+                $payload = decodeJsonBody();
+                $valeur = sanitizeInt($payload['valeur'] ?? null, $action === 'set');
+                $result = withData(function (array &$data) use ($id, $action, $valeur, $user) {
+                    foreach ($data['bijoux'] as &$bijou) {
+                        if (($bijou['id'] ?? '') === $id) {
+                            return applyStockOperation($bijou, $action, $valeur, $user, $data['logs']);
+                        }
+                    }
+                    throw new RuntimeException('Bijou introuvable.', 404);
+                });
+                respond($result);
+            }
+
+            if ($resource === 'import' && isset($_FILES['fichier'])) {
+                $result = handleCsvImport($_FILES['fichier'], $user);
+                respond(['import' => $result]);
+            }
+
+            errorResponse('Ressource inconnue.', 400);
+
+        case 'PUT':
+            if ($resource === 'bijoux' && $id) {
+                $payload = decodeJsonBody();
+                $payload['id'] = $id;
+                $bijou = validateBijou($payload);
+                $result = withData(function (array &$data) use ($bijou, $user) {
+                    foreach ($data['bijoux'] as &$existing) {
+                        if (($existing['id'] ?? '') === $bijou['id']) {
+                            $changes = [];
+                            if ($existing['titre_court'] !== $bijou['titre_court']) {
+                                $changes[] = buildTitleHistory($bijou['id'], $user, 'titre_court', $existing['titre_court'] ?? '', $bijou['titre_court']);
+                            }
+                            $existing = array_merge($existing, $bijou);
+                            foreach ($changes as $entry) {
+                                $data['titres'][] = $entry;
+                            }
+                            return ['bijou' => $existing];
+                        }
+                    }
+                    throw new RuntimeException('Bijou introuvable.', 404);
+                });
+                respond($result);
+            }
+            errorResponse('Ressource inconnue pour mise à jour.', 400);
+
+        case 'DELETE':
+            if ($resource === 'bijoux' && $id) {
+                $result = withData(function (array &$data) use ($id) {
+                    foreach ($data['bijoux'] as $index => $bijou) {
+                        if (($bijou['id'] ?? '') === $id) {
+                            array_splice($data['bijoux'], $index, 1);
+                            return ['supprime' => true];
+                        }
+                    }
+                    throw new RuntimeException('Bijou introuvable.', 404);
+                });
+                respond($result);
+            }
+            errorResponse('Suppression non autorisée.', 405);
+
+        default:
+            errorResponse('Méthode non prise en charge.', 405);
+    }
+} catch (InvalidArgumentException $exception) {
+    errorResponse($exception->getMessage(), 400);
+} catch (RuntimeException $exception) {
+    $code = $exception->getCode();
+    if ($code < 400 || $code > 599) {
+        $code = 400;
+    }
+    error_log($exception->getMessage());
+    errorResponse($exception->getMessage(), $code);
+} catch (Throwable $exception) {
+    error_log($exception->getMessage());
+    errorResponse('Erreur interne du serveur.', 500);
+}

--- a/inventaire-bijoux.html
+++ b/inventaire-bijoux.html
@@ -1,0 +1,1052 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventaire Bijoux</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --primary: #d4af37;
+            --primary-dark: #b4881d;
+            --primary-light: #f6e5b8;
+            --background: #faf9f6;
+            --surface: #ffffff;
+            --surface-alt: #fdf7ec;
+            --text: #2c2a27;
+            --text-muted: #7a756d;
+            --border: #ece6da;
+            --danger: #d14343;
+            --success: #2f9e44;
+            --warning: #e67700;
+            --radius: 16px;
+            --shadow: 0 12px 32px rgba(44, 42, 39, 0.08);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            margin: 0;
+            background: radial-gradient(circle at top, var(--surface-alt), var(--background));
+            color: var(--text);
+            min-height: 100vh;
+        }
+
+        header {
+            padding: 2.5rem 1.5rem 2rem;
+            text-align: center;
+        }
+
+        header h1 {
+            font-size: clamp(2.2rem, 5vw, 3.2rem);
+            margin-bottom: 0.5rem;
+            font-weight: 700;
+            letter-spacing: -0.02em;
+        }
+
+        header p {
+            max-width: 720px;
+            margin: 0 auto;
+            color: var(--text-muted);
+            font-size: 1rem;
+        }
+
+        main {
+            padding: 0 1.5rem 3rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        @media (min-width: 1024px) {
+            .grid {
+                grid-template-columns: 380px 1fr;
+                align-items: start;
+            }
+        }
+
+        .card {
+            background: var(--surface);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            border: 1px solid rgba(212, 175, 55, 0.1);
+            padding: 1.5rem;
+        }
+
+        .card h2 {
+            margin-top: 0;
+            font-size: 1.4rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .card h2 span.badge {
+            background: rgba(212, 175, 55, 0.16);
+            color: var(--primary-dark);
+            font-size: 0.75rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+        }
+
+        form label {
+            display: block;
+            margin-bottom: 0.4rem;
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        form input[type="text"],
+        form input[type="number"],
+        form textarea,
+        form select {
+            width: 100%;
+            padding: 0.7rem 0.8rem;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.86);
+            transition: border-color 0.2s ease;
+            font-size: 0.95rem;
+        }
+
+        form input[type="text"]:focus,
+        form input[type="number"]:focus,
+        form textarea:focus,
+        form select:focus {
+            outline: none;
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(212, 175, 55, 0.2);
+        }
+
+        .field-group {
+            margin-bottom: 1rem;
+        }
+
+        .inline-fields {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-top: 1.5rem;
+        }
+
+        button, .button {
+            border: none;
+            cursor: pointer;
+            border-radius: 999px;
+            padding: 0.65rem 1.1rem;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button.primary {
+            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+            color: #fff;
+            box-shadow: 0 10px 20px rgba(180, 136, 29, 0.3);
+        }
+
+        button.secondary {
+            background: rgba(212, 175, 55, 0.15);
+            color: var(--primary-dark);
+        }
+
+        button.danger {
+            background: rgba(209, 67, 67, 0.12);
+            color: var(--danger);
+        }
+
+        button:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+        }
+
+        button:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 20px rgba(212, 175, 55, 0.18);
+        }
+
+        .table-wrapper {
+            overflow-x: auto;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 720px;
+        }
+
+        th, td {
+            text-align: left;
+            padding: 0.75rem;
+            border-bottom: 1px solid rgba(44, 42, 39, 0.08);
+            font-size: 0.92rem;
+            vertical-align: top;
+        }
+
+        th {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            color: var(--text-muted);
+        }
+
+        tr.low-stock td {
+            background: rgba(230, 119, 0, 0.06);
+        }
+
+        tr.out-of-stock td {
+            background: rgba(209, 67, 67, 0.06);
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.25rem 0.6rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .badge.warning {
+            background: rgba(230, 119, 0, 0.16);
+            color: var(--warning);
+        }
+
+        .badge.danger {
+            background: rgba(209, 67, 67, 0.16);
+            color: var(--danger);
+        }
+
+        .badge.muted {
+            background: rgba(44, 42, 39, 0.08);
+            color: var(--text-muted);
+        }
+
+        .stock-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .filters {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .filters button {
+            background: rgba(212, 175, 55, 0.12);
+            color: var(--primary-dark);
+        }
+
+        .filters button.active {
+            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+            color: #fff;
+        }
+
+        .chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 0.75rem;
+        }
+
+        .chip {
+            background: rgba(44, 42, 39, 0.08);
+            padding: 0.3rem 0.6rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 2rem 1rem;
+            color: var(--text-muted);
+        }
+
+        .toast {
+            position: fixed;
+            top: 1.5rem;
+            right: 1.5rem;
+            background: var(--surface);
+            border-radius: 12px;
+            box-shadow: var(--shadow);
+            padding: 1rem 1.2rem;
+            border-left: 4px solid var(--primary);
+            min-width: 240px;
+            display: none;
+        }
+
+        .toast.show {
+            display: block;
+        }
+
+        .alert-panel {
+            background: rgba(230, 119, 0, 0.1);
+            border: 1px solid rgba(230, 119, 0, 0.3);
+            color: var(--warning);
+            border-radius: 12px;
+            padding: 0.9rem 1rem;
+            margin-bottom: 1rem;
+            display: none;
+        }
+
+        .alert-panel.show {
+            display: block;
+        }
+
+        .photo-previews {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+        }
+
+        .photo-previews img {
+            width: 64px;
+            height: 64px;
+            object-fit: cover;
+            border-radius: 12px;
+            border: 1px solid rgba(44, 42, 39, 0.1);
+        }
+
+        .history-modal {
+            position: fixed;
+            inset: 0;
+            background: rgba(44, 42, 39, 0.45);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            z-index: 1000;
+        }
+
+        .history-modal.show {
+            display: flex;
+        }
+
+        .history-content {
+            background: var(--surface);
+            border-radius: 18px;
+            padding: 1.5rem;
+            width: min(600px, 100%);
+            max-height: 80vh;
+            overflow-y: auto;
+            box-shadow: var(--shadow);
+        }
+
+        .history-content h3 {
+            margin-top: 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .history-list {
+            margin-top: 1rem;
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .history-item {
+            padding: 0.75rem 1rem;
+            border-radius: 12px;
+            background: rgba(44, 42, 39, 0.05);
+            border: 1px solid rgba(44, 42, 39, 0.06);
+        }
+
+        .history-item strong {
+            display: block;
+            margin-bottom: 0.2rem;
+        }
+
+        .history-item small {
+            color: var(--text-muted);
+        }
+
+        .import-export {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .warning-text {
+            background: rgba(230, 119, 0, 0.12);
+            border-radius: 12px;
+            padding: 0.75rem 0.9rem;
+            font-size: 0.85rem;
+            margin-top: 0.75rem;
+            color: var(--warning);
+        }
+
+        .title-alert {
+            display: none;
+            margin-top: 0.75rem;
+            padding: 0.75rem;
+            border-radius: 12px;
+            background: rgba(230, 119, 0, 0.12);
+            color: var(--warning);
+            font-size: 0.9rem;
+        }
+
+        .title-alert.show {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Inventaire Bijoux</h1>
+        <p>Pilotage complet de vos bijoux : génération automatique de titres, suivi des stocks en temps réel, réservations, ventes et historique détaillé des ajustements.</p>
+    </header>
+    <main>
+        <div class="alert-panel" id="alert-panel"></div>
+        <div class="grid">
+            <section class="card" aria-label="Formulaire de bijou">
+                <h2>Fiche bijou <span class="badge" id="mode-badge">Nouveau</span></h2>
+                <form id="bijou-form">
+                    <input type="hidden" id="bijou-id">
+                    <div class="field-group">
+                        <label for="type">Type *</label>
+                        <select id="type" required>
+                            <option value="">Sélectionner</option>
+                            <option value="collier">Collier</option>
+                            <option value="boucles">Boucles</option>
+                            <option value="bracelet">Bracelet</option>
+                        </select>
+                    </div>
+                    <div class="field-group inline-fields">
+                        <div>
+                            <label for="matiere">Matière *</label>
+                            <input type="text" id="matiere" required placeholder="Argent 925, Or 18k...">
+                        </div>
+                        <div>
+                            <label for="caracteristique">Caractéristique principale *</label>
+                            <input type="text" id="caracteristique" required placeholder="Perle, pendentif...">
+                        </div>
+                    </div>
+                    <div class="field-group">
+                        <label for="dimensions">Dimensions (cm) *</label>
+                        <input type="text" id="dimensions" required placeholder="Longueur 45 cm / pendentif 1.8×1.2 cm">
+                    </div>
+                    <div class="field-group inline-fields">
+                        <div>
+                            <label for="couleur">Couleur</label>
+                            <input type="text" id="couleur" placeholder="Argent, Doré...">
+                        </div>
+                        <div>
+                            <label for="couleurs">Couleur(s) complémentaire(s)</label>
+                            <input type="text" id="couleurs" placeholder="Rose gold, perle ivoire...">
+                        </div>
+                    </div>
+                    <div class="field-group">
+                        <label for="photos">Photos</label>
+                        <input type="file" id="photos" accept="image/*" multiple>
+                        <div class="photo-previews" id="photo-previews"></div>
+                    </div>
+                    <div class="field-group inline-fields">
+                        <div>
+                            <label for="quantite">Quantité *</label>
+                            <input type="number" id="quantite" min="0" value="0" required>
+                        </div>
+                        <div>
+                            <label for="seuil_bas">Seuil bas</label>
+                            <input type="number" id="seuil_bas" min="0" value="0">
+                        </div>
+                        <div>
+                            <label for="prix_achat">Prix d'achat (€)</label>
+                            <input type="number" step="0.01" min="0" id="prix_achat" placeholder="Optionnel">
+                        </div>
+                    </div>
+                    <div class="field-group inline-fields">
+                        <div>
+                            <label for="marque">Marque</label>
+                            <input type="text" id="marque" placeholder="Optionnel">
+                        </div>
+                        <div>
+                            <label for="etat">État</label>
+                            <input type="text" id="etat" placeholder="Neuf, Excellent...">
+                        </div>
+                        <div>
+                            <label for="defauts">Défauts</label>
+                            <input type="text" id="defauts" placeholder="Optionnel">
+                        </div>
+                    </div>
+                    <div class="field-group">
+                        <label>
+                            <input type="checkbox" id="flag_a_renseigner">
+                            Informations à compléter
+                        </label>
+                    </div>
+                    <div class="field-group">
+                        <label for="titre_court">Titre court</label>
+                        <div class="actions" style="margin:0.4rem 0;">
+                            <button type="button" class="secondary" id="btn-generer-titre">Générer automatiquement</button>
+                            <button type="button" class="secondary" id="btn-historique-titres">Historique des titres</button>
+                        </div>
+                        <input type="text" id="titre_court" placeholder="Titre d'affichage">
+                        <div class="title-alert" id="titre-alert">Impossible de générer un titre automatique : merci de compléter les champs requis.</div>
+                    </div>
+                    <div class="actions">
+                        <button type="submit" class="primary" id="btn-enregistrer">Enregistrer</button>
+                        <button type="button" class="secondary" id="btn-annuler">Réinitialiser</button>
+                    </div>
+                </form>
+            </section>
+            <section class="card" aria-label="Inventaire">
+                <h2>Inventaire <span class="badge muted" id="inventaire-total">0 articles</span></h2>
+                <div class="filters" role="tablist" aria-label="Filtres d'état">
+                    <button type="button" class="active" data-filter="all">Tous</button>
+                    <button type="button" data-filter="stock">En stock</button>
+                    <button type="button" data-filter="low">À réapprovisionner</button>
+                    <button type="button" data-filter="out">Épuisés</button>
+                </div>
+                <div class="import-export">
+                    <label class="button secondary" for="csv-import">Importer CSV</label>
+                    <input type="file" id="csv-import" accept=".csv" hidden>
+                    <button type="button" class="secondary" id="btn-export">Exporter CSV</button>
+                    <span class="chip">Token API : inventaire-bijoux-token</span>
+                </div>
+                <div class="table-wrapper">
+                    <table aria-live="polite">
+                        <thead>
+                            <tr>
+                                <th>Photo</th>
+                                <th>Titre</th>
+                                <th>Type</th>
+                                <th>Matière</th>
+                                <th>Qté</th>
+                                <th>Seuil</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="inventaire-body"></tbody>
+                    </table>
+                </div>
+                <div class="empty-state" id="empty-state">Aucun bijou enregistré pour le moment.</div>
+            </section>
+        </div>
+    </main>
+
+    <div class="toast" id="toast" role="status"></div>
+
+    <div class="history-modal" id="history-modal" aria-hidden="true">
+        <div class="history-content">
+            <h3>Historique <button type="button" class="secondary" id="close-history">Fermer</button></h3>
+            <div class="history-list" id="history-list"></div>
+        </div>
+    </div>
+
+    <div class="history-modal" id="title-history-modal" aria-hidden="true">
+        <div class="history-content">
+            <h3>Historique des titres <button type="button" class="secondary" id="close-title-history">Fermer</button></h3>
+            <div class="history-list" id="title-history-list"></div>
+        </div>
+    </div>
+
+    <script>
+        const API_BASE = 'api/bijoux.php';
+        const API_TOKEN = 'inventaire-bijoux-token';
+        const DEFAULT_USER = 'admin';
+
+        const form = document.getElementById('bijou-form');
+        const modeBadge = document.getElementById('mode-badge');
+        const inventaireBody = document.getElementById('inventaire-body');
+        const inventaireTotal = document.getElementById('inventaire-total');
+        const emptyState = document.getElementById('empty-state');
+        const alertPanel = document.getElementById('alert-panel');
+        const toast = document.getElementById('toast');
+        const photoInput = document.getElementById('photos');
+        const photoPreview = document.getElementById('photo-previews');
+        const csvImport = document.getElementById('csv-import');
+        const historyModal = document.getElementById('history-modal');
+        const historyList = document.getElementById('history-list');
+        const titleHistoryModal = document.getElementById('title-history-modal');
+        const titleHistoryList = document.getElementById('title-history-list');
+        const titleAlert = document.getElementById('titre-alert');
+
+        let bijoux = [];
+        let currentFilter = 'all';
+        let currentPhotos = [];
+
+        const fields = {
+            id: document.getElementById('bijou-id'),
+            type: document.getElementById('type'),
+            matiere: document.getElementById('matiere'),
+            caracteristique: document.getElementById('caracteristique'),
+            dimensions: document.getElementById('dimensions'),
+            couleur: document.getElementById('couleur'),
+            couleurs: document.getElementById('couleurs'),
+            quantite: document.getElementById('quantite'),
+            seuil_bas: document.getElementById('seuil_bas'),
+            prix_achat: document.getElementById('prix_achat'),
+            flag: document.getElementById('flag_a_renseigner'),
+            titre_court: document.getElementById('titre_court'),
+            marque: document.getElementById('marque'),
+            etat: document.getElementById('etat'),
+            defauts: document.getElementById('defauts')
+        };
+
+        function showToast(message, type = 'info') {
+            toast.textContent = message;
+            toast.style.borderLeftColor = type === 'error' ? 'var(--danger)' : 'var(--primary)';
+            toast.classList.add('show');
+            setTimeout(() => toast.classList.remove('show'), 3500);
+        }
+
+        async function apiFetch(path, options = {}) {
+            const headers = options.headers || {};
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            headers['Authorization'] = 'Bearer ' + API_TOKEN;
+            headers['X-User'] = DEFAULT_USER;
+            const response = await fetch(`${API_BASE}${path}`, {
+                credentials: 'omit',
+                ...options,
+                headers
+            });
+            if (!response.ok) {
+                const message = await response.text();
+                throw new Error(message || 'Erreur API');
+            }
+            if (response.headers.get('Content-Type')?.includes('application/json')) {
+                return response.json();
+            }
+            return response;
+        }
+
+        function resetForm() {
+            form.reset();
+            fields.id.value = '';
+            fields.quantite.value = 0;
+            fields.seuil_bas.value = 0;
+            currentPhotos = [];
+            renderPhotos();
+            modeBadge.textContent = 'Nouveau';
+            titleAlert.classList.remove('show');
+        }
+
+        function renderPhotos() {
+            photoPreview.innerHTML = currentPhotos.map(src => `<img src="${src}" alt="Photo bijou">`).join('');
+        }
+
+        function extractPrimaryDimension(dimensions) {
+            if (!dimensions) return '';
+            const parts = dimensions.split(/[\/]/);
+            return parts[0]?.trim() || dimensions.trim();
+        }
+
+        function generateTitlesFromValues(type, matiere, caracteristique, dimensions) {
+            if (!type || !matiere || !caracteristique || !dimensions) {
+                return { titre_court: '', avertissement: true };
+            }
+            const dimensionPrincipale = extractPrimaryDimension(dimensions);
+            const typeLabel = type.charAt(0).toUpperCase() + type.slice(1);
+            const titreCourt = `${typeLabel} ${matiere} ${caracteristique} ${dimensionPrincipale}`.replace(/\s+/g, ' ').trim();
+            return { titre_court: titreCourt, avertissement: false };
+        }
+
+        function generateTitlesFromForm() {
+            const result = generateTitlesFromValues(fields.type.value, fields.matiere.value, fields.caracteristique.value, fields.dimensions.value);
+            fields.titre_court.value = result.titre_court;
+            if (result.avertissement) {
+                titleAlert.classList.add('show');
+            } else {
+                titleAlert.classList.remove('show');
+            }
+            return result;
+        }
+
+        async function loadBijoux() {
+            try {
+                const data = await apiFetch('?resource=bijoux');
+                bijoux = data.bijoux || [];
+                renderInventory();
+            } catch (error) {
+                showToast('Impossible de charger les bijoux.', 'error');
+                console.error(error);
+            }
+        }
+
+        function renderAlerts() {
+            const lowStock = bijoux.filter(item => item.seuil_bas > 0 && item.quantite <= item.seuil_bas);
+            if (lowStock.length > 0) {
+                alertPanel.classList.add('show');
+                const items = lowStock.map(item => `<strong>${item.titre_court || item.id}</strong> : ${item.quantite} unité(s) (seuil ${item.seuil_bas})`).join('<br>');
+                alertPanel.innerHTML = `<strong>Alertes de stock bas :</strong><br>${items}`;
+            } else {
+                alertPanel.classList.remove('show');
+                alertPanel.textContent = '';
+            }
+        }
+
+        function filteredBijoux() {
+            return bijoux.filter(item => {
+                if (currentFilter === 'low') {
+                    return item.seuil_bas > 0 && item.quantite > 0 && item.quantite <= item.seuil_bas;
+                }
+                if (currentFilter === 'out') {
+                    return item.quantite === 0;
+                }
+                if (currentFilter === 'stock') {
+                    return item.quantite > (item.seuil_bas || 0);
+                }
+                return true;
+            });
+        }
+
+        function renderInventory() {
+            renderAlerts();
+            const list = filteredBijoux();
+            inventaireTotal.textContent = `${bijoux.length} article${bijoux.length > 1 ? 's' : ''}`;
+            emptyState.style.display = list.length === 0 ? 'block' : 'none';
+
+            inventaireBody.innerHTML = list.map(item => {
+                const badge = item.quantite === 0
+                    ? '<span class="badge danger">Épuisé</span>'
+                    : (item.seuil_bas > 0 && item.quantite <= item.seuil_bas
+                        ? '<span class="badge warning">Seuil bas</span>'
+                        : '');
+                const rowClass = item.quantite === 0 ? 'out-of-stock' : (item.seuil_bas > 0 && item.quantite <= item.seuil_bas ? 'low-stock' : '');
+                const photo = item.photos?.[0]
+                    ? `<img src="${item.photos[0]}" alt="${item.titre_court}" style="width:56px;height:56px;object-fit:cover;border-radius:12px;">`
+                    : '<span class="chip">Pas de photo</span>';
+                return `
+                    <tr class="${rowClass}">
+                        <td>${photo}</td>
+                        <td>
+                            <strong>${item.titre_court || 'Titre à renseigner'}</strong>
+                            ${badge}
+                            <div class="chips">
+                                <span class="chip">${item.dimensions}</span>
+                                ${item.flag_a_renseigner ? '<span class="chip">À compléter</span>' : ''}
+                            </div>
+                        </td>
+                        <td>${item.type}</td>
+                        <td>${item.matiere}</td>
+                        <td>${item.quantite}</td>
+                        <td>${item.seuil_bas}</td>
+                        <td>
+                            <div class="stock-actions" role="group" aria-label="Actions stock">
+                                <button type="button" class="secondary" data-action="add" data-id="${item.id}">+ Ajouter</button>
+                                <button type="button" class="secondary" data-action="remove" data-id="${item.id}">- Retirer</button>
+                                <button type="button" class="secondary" data-action="reserve" data-id="${item.id}">Réserver</button>
+                                <button type="button" class="secondary" data-action="sold" data-id="${item.id}">Vendu</button>
+                                <button type="button" class="secondary" data-action="set" data-id="${item.id}">Définir</button>
+                                <button type="button" class="secondary" data-action="edit" data-id="${item.id}">Éditer</button>
+                                <button type="button" class="secondary" data-action="history" data-id="${item.id}">Historique</button>
+                            </div>
+                        </td>
+                    </tr>`;
+            }).join('');
+        }
+
+        function getFormPayload() {
+            const titreGeneration = generateTitlesFromValues(fields.type.value, fields.matiere.value, fields.caracteristique.value, fields.dimensions.value);
+            const titreAvertissement = titreGeneration.avertissement && !fields.titre_court.value;
+            return {
+                id: fields.id.value,
+                type: fields.type.value,
+                matiere: fields.matiere.value.trim(),
+                caracteristique: fields.caracteristique.value.trim(),
+                dimensions: fields.dimensions.value.trim(),
+                couleur: fields.couleur.value.trim(),
+                couleurs: fields.couleurs.value.trim(),
+                photos: currentPhotos,
+                quantite: Number(fields.quantite.value || 0),
+                seuil_bas: Number(fields.seuil_bas.value || 0),
+                prix_achat: fields.prix_achat.value !== '' ? Number(fields.prix_achat.value) : null,
+                flag_a_renseigner: fields.flag.checked,
+                titre_court: fields.titre_court.value.trim(),
+                titre_avertissement: titreAvertissement,
+                marque: fields.marque.value.trim(),
+                etat: fields.etat.value.trim(),
+                defauts: fields.defauts.value.trim()
+            };
+        }
+
+        function populateForm(bijou) {
+            fields.id.value = bijou.id;
+            fields.type.value = bijou.type;
+            fields.matiere.value = bijou.matiere || '';
+            fields.caracteristique.value = bijou.caracteristique || '';
+            fields.dimensions.value = bijou.dimensions || '';
+            fields.couleur.value = bijou.couleur || '';
+            fields.couleurs.value = bijou.couleurs || '';
+            fields.quantite.value = bijou.quantite ?? 0;
+            fields.seuil_bas.value = bijou.seuil_bas ?? 0;
+            fields.prix_achat.value = bijou.prix_achat ?? '';
+            fields.flag.checked = Boolean(bijou.flag_a_renseigner);
+            fields.titre_court.value = bijou.titre_court || '';
+            fields.marque.value = bijou.marque || '';
+            fields.etat.value = bijou.etat || '';
+            fields.defauts.value = bijou.defauts || '';
+            currentPhotos = Array.isArray(bijou.photos) ? bijou.photos : [];
+            renderPhotos();
+            modeBadge.textContent = 'Édition';
+            titleAlert.classList.toggle('show', Boolean(bijou.titre_avertissement));
+        }
+
+        async function submitForm(event) {
+            event.preventDefault();
+            if (!form.reportValidity()) {
+                return;
+            }
+            const payload = getFormPayload();
+            const method = payload.id ? 'PUT' : 'POST';
+            const path = payload.id ? `?resource=bijoux&id=${encodeURIComponent(payload.id)}` : '?resource=bijoux';
+            try {
+                await apiFetch(path, {
+                    method,
+                    body: JSON.stringify(payload)
+                });
+                showToast('Bijou enregistré.');
+                resetForm();
+                await loadBijoux();
+            } catch (error) {
+                console.error(error);
+                showToast('Erreur lors de l\'enregistrement.', 'error');
+            }
+        }
+
+        function promptQuantity(action) {
+            let message = 'Quantité à appliquer';
+            switch (action) {
+                case 'add':
+                    message = 'Quantité à ajouter';
+                    break;
+                case 'remove':
+                    message = 'Quantité à retirer';
+                    break;
+                case 'reserve':
+                    message = 'Quantité à réserver';
+                    break;
+                case 'sold':
+                    message = 'Quantité vendue';
+                    break;
+                case 'set':
+                    message = 'Nouvelle quantité';
+                    break;
+            }
+            const value = prompt(message);
+            if (value === null) return null;
+            const parsed = Number(value);
+            if (!Number.isInteger(parsed) || parsed < 0) {
+                alert('Veuillez saisir un entier valide.');
+                return null;
+            }
+            if (action !== 'set' && parsed === 0) {
+                alert('La valeur doit être supérieure à zéro.');
+                return null;
+            }
+            return parsed;
+        }
+
+        async function handleStockAction(id, action) {
+            const valeur = promptQuantity(action);
+            if (valeur === null) return;
+            try {
+                await apiFetch(`?resource=stock&id=${encodeURIComponent(id)}&action=${action}`, {
+                    method: 'POST',
+                    body: JSON.stringify({ valeur })
+                });
+                showToast('Stock mis à jour.');
+                await loadBijoux();
+            } catch (error) {
+                console.error(error);
+                showToast('Impossible de modifier le stock.', 'error');
+            }
+        }
+
+        async function openHistory(id) {
+            try {
+                const data = await apiFetch(`?resource=historique&bijou_id=${encodeURIComponent(id)}&per_page=50`);
+                const items = data.logs || [];
+                historyList.innerHTML = items.length
+                    ? items.map(log => `
+                        <div class="history-item">
+                            <strong>${log.action.toUpperCase()}</strong>
+                            <div>Variation : ${log.delta > 0 ? '+' : ''}${log.delta}</div>
+                            <div>Nouvelle quantité : ${log.nouvelle_quantite}</div>
+                            <small>${new Date(log.timestamp).toLocaleString()} – ${log.utilisateur}</small>
+                        </div>`).join('')
+                    : '<p>Aucune opération enregistrée.</p>';
+                historyModal.classList.add('show');
+                historyModal.setAttribute('aria-hidden', 'false');
+            } catch (error) {
+                console.error(error);
+                showToast('Historique indisponible.', 'error');
+            }
+        }
+
+        async function openTitleHistory(id) {
+            try {
+                const data = await apiFetch(`?resource=titres&bijou_id=${encodeURIComponent(id)}`);
+                const items = data.titres || [];
+                titleHistoryList.innerHTML = items.length
+                    ? items.map(entry => `
+                        <div class="history-item">
+                            <strong>${entry.champ}</strong>
+                            <div>Ancien : ${entry.ancienne_valeur || '<em>vide</em>'}</div>
+                            <div>Nouveau : ${entry.nouvelle_valeur || '<em>vide</em>'}</div>
+                            <small>${new Date(entry.timestamp).toLocaleString()} – ${entry.utilisateur}</small>
+                        </div>`).join('')
+                    : '<p>Aucune modification enregistrée.</p>';
+                titleHistoryModal.classList.add('show');
+                titleHistoryModal.setAttribute('aria-hidden', 'false');
+            } catch (error) {
+                console.error(error);
+                showToast('Historique des titres indisponible.', 'error');
+            }
+        }
+
+        function handleTableClick(event) {
+            const button = event.target.closest('button[data-action]');
+            if (!button) return;
+            const action = button.dataset.action;
+            const id = button.dataset.id;
+            const bijou = bijoux.find(item => item.id === id);
+            if (!bijou) return;
+            if (action === 'edit') {
+                populateForm(bijou);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            } else if (action === 'history') {
+                openHistory(id);
+            } else {
+                handleStockAction(id, action);
+            }
+        }
+
+        function closeHistoryModal() {
+            historyModal.classList.remove('show');
+            historyModal.setAttribute('aria-hidden', 'true');
+        }
+
+        function closeTitleHistoryModal() {
+            titleHistoryModal.classList.remove('show');
+            titleHistoryModal.setAttribute('aria-hidden', 'true');
+        }
+
+        function handleFilterClick(event) {
+            const button = event.target.closest('button[data-filter]');
+            if (!button) return;
+            currentFilter = button.dataset.filter;
+            document.querySelectorAll('.filters button').forEach(btn => btn.classList.toggle('active', btn === button));
+            renderInventory();
+        }
+
+        photoInput.addEventListener('change', async () => {
+            const files = Array.from(photoInput.files || []);
+            const promises = files.map(file => new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = reject;
+                reader.readAsDataURL(file);
+            }));
+            try {
+                const images = await Promise.all(promises);
+                currentPhotos = images;
+                renderPhotos();
+            } catch (error) {
+                console.error(error);
+                showToast('Erreur lors du chargement des photos.', 'error');
+            }
+        });
+
+        csvImport.addEventListener('change', async () => {
+            const file = csvImport.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('fichier', file);
+            try {
+                const response = await fetch(`${API_BASE}?resource=import`, {
+                    method: 'POST',
+                    headers: {
+                        'Authorization': 'Bearer ' + API_TOKEN,
+                        'X-User': DEFAULT_USER
+                    },
+                    body: formData
+                });
+                if (!response.ok) {
+                    throw new Error(await response.text());
+                }
+                const result = await response.json();
+                showToast(`Import réussi : ${result.import.crees} créés, ${result.import.mis_a_jour} mis à jour.`);
+                await loadBijoux();
+            } catch (error) {
+                console.error(error);
+                showToast('Échec de l\'import CSV.', 'error');
+            } finally {
+                csvImport.value = '';
+            }
+        });
+
+        document.getElementById('btn-export').addEventListener('click', async () => {
+            try {
+                const response = await fetch(`${API_BASE}?resource=export`, {
+                    headers: {
+                        'Authorization': 'Bearer ' + API_TOKEN,
+                        'X-User': DEFAULT_USER
+                    }
+                });
+                if (!response.ok) {
+                    throw new Error(await response.text());
+                }
+                const blob = await response.blob();
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'inventaire_bijoux.csv';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+                showToast('Export CSV généré.');
+            } catch (error) {
+                console.error(error);
+                showToast('Impossible d\'exporter le CSV.', 'error');
+            }
+        });
+
+        document.getElementById('btn-generer-titre').addEventListener('click', generateTitlesFromForm);
+        document.getElementById('btn-historique-titres').addEventListener('click', () => {
+            const id = fields.id.value;
+            if (!id) {
+                showToast('Enregistrez le bijou pour consulter l\'historique des titres.', 'error');
+                return;
+            }
+            openTitleHistory(id);
+        });
+        document.getElementById('btn-annuler').addEventListener('click', resetForm);
+        document.getElementById('close-history').addEventListener('click', closeHistoryModal);
+        document.getElementById('close-title-history').addEventListener('click', closeTitleHistoryModal);
+        historyModal.addEventListener('click', event => { if (event.target === historyModal) closeHistoryModal(); });
+        titleHistoryModal.addEventListener('click', event => { if (event.target === titleHistoryModal) closeTitleHistoryModal(); });
+        form.addEventListener('submit', submitForm);
+        inventaireBody.addEventListener('click', handleTableClick);
+        document.querySelector('.filters').addEventListener('click', handleFilterClick);
+
+        resetForm();
+        loadBijoux();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the SEO title field from the Inventaire Bijoux form and client logic
- simplify the bijoux API to drop titre_seo processing, CSV export column, and history tracking
- keep automatic titre_court generation with the existing warning flow

## Testing
- php -l api/bijoux.php

------
https://chatgpt.com/codex/tasks/task_e_68e205e182f0832f8e4c0d61929042d3