### PR TITLE
Fix REST API route registration and frontend endpoint URLs

### DIFF
--- a/V22.html
+++ b/V22.html
@@ -1,0 +1,724 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Gestion des Stocks SEMPA v2.4</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        :root{color-scheme:light;--bg:#f8f9fa;--bg-alt:#e9ecef;--surface:#fff;--surface-alt:#f8f9fa;--border:rgba(0,0,0,.08);--border-strong:rgba(0,0,0,.15);--shadow-sm:0 4px 12px rgba(0,0,0,.06);--shadow-lg:0 1rem 3rem rgba(0,0,0,.175);--primary:#ff9f1c;--primary-dark:#e78f17;--primary-soft:rgba(255,159,28,.16);--text:#212529;--text-muted:#6c757d;--text-subtle:#adb5bd;--danger:#dc3545;--success:#198754;--warning:#ffc107;--radius-md:12px;--radius-lg:18px;--transition:.2s ease}#stock-app-wrapper{font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased;transition:background .2s,color .2s}#stock-app-wrapper.dark-theme{color-scheme:dark;--bg:#0f172a;--bg-alt:#1e293b;--surface:#1e293b;--surface-alt:#0f172a;--border:rgba(255,255,255,.12);--border-strong:rgba(255,255,255,.2);--shadow-sm:0 4px 12px rgba(0,0,0,.3);--shadow-lg:0 1rem 3rem rgba(0,0,0,.5);--text:#e2e8f0;--text-muted:#94a3b8;--text-subtle:#475569}*,:after,:before{box-sizing:border-box}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:600;line-height:1.2}h1{font-size:1.75rem}h2{font-size:1.5rem}h3{font-size:1.25rem}p{margin-top:0;margin-bottom:1rem}.brand p{margin-top:2px;font-size:.9rem;color:var(--text-muted)}.app-shell{min-height:100vh;display:flex;flex-direction:column}.app-header{position:sticky;top:0;z-index:1020;padding:1rem 1.5rem;background:rgba(255,255,255,.8);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);border-bottom:1px solid var(--border)}.dark-theme .app-header{background:rgba(15,23,42,.8)}.header-inner{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem;max-width:1400px;margin:0 auto}.card{border-radius:var(--radius-md);border:1px solid var(--border);padding:1.5rem;box-shadow:var(--shadow-sm);background:var(--surface)}.btn-primary,.btn-ghost,.btn-danger,.icon-button{cursor:pointer;transition:all .2s ease;font-weight:600;display:inline-flex;align-items:center;justify-content:center;gap:.5rem}.btn-primary:hover,.btn-ghost:hover,.btn-danger:hover,.icon-button:hover{transform:translateY(-1px)}.btn-primary{border:none;border-radius:var(--radius-md);background:linear-gradient(135deg,var(--primary),var(--primary-dark));color:#fff!important;padding:.6rem 1rem}.btn-ghost{border:1px solid var(--border-strong);border-radius:var(--radius-md);background:0 0;color:var(--text);padding:.5rem 1rem}.btn-danger{border:1px solid var(--danger);background:rgba(220,53,69,.1);color:var(--danger);border-radius:var(--radius-md);padding:.25rem .5rem}.icon-button{border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface);display:grid;place-items:center;width:40px;height:40px}.main-content{flex:1;padding:1.5rem}.content-max{max-width:1400px;margin:0 auto}.sempa-tabs{display:flex;gap:4px;padding:4px;background:var(--bg-alt);border-radius:var(--radius-md);overflow-x:auto;margin-bottom:1.5rem}.sempa-tab{border:none;border-radius:10px;background:0 0;padding:.5rem 1rem;font-weight:600;white-space:nowrap;color:var(--text-muted)}.sempa-tab.active{background:var(--surface);color:var(--text);box-shadow:var(--shadow-sm)}.sempa-content{display:none}.sempa-content.active{display:block;animation:fade .3s}@keyframes fade{from{opacity:0}to{opacity:1}}.metrics-grid{display:grid;gap:1.5rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin-bottom:1.5rem}.metric-card{padding:1.5rem}.dashboard-grid{display:grid;gap:1.5rem}@media(min-width:992px){.dashboard-grid.cols-2{grid-template-columns:1fr 1fr}}.table-wrapper{overflow-x:auto}.product-thumbnail{width:40px;height:40px;object-fit:cover;border-radius:6px;background:var(--bg-alt)}.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;place-items:center;z-index:1050;padding:1rem}.modal-backdrop.open{display:grid}.modal-panel{width:min(920px,95vw);max-height:90vh;display:flex;flex-direction:column;background:var(--surface);border-radius:var(--radius-lg);box-shadow:var(--shadow-lg)}.modal-header{padding:1rem 1.5rem;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center}.modal-body{padding:1.5rem;overflow-y:auto;flex:1;display:grid;grid-template-columns:220px 1fr;gap:1.5rem}.modal-actions{padding:1rem 1.5rem;border-top:1px solid var(--border);display:flex;justify-content:flex-end;gap:.75rem}.photo-uploader .preview{width:100%;height:180px;background:var(--bg-alt);border-radius:var(--radius-md);margin-bottom:1rem;border:2px dashed var(--border);display:flex;align-items:center;justify-content:center;color:var(--text-subtle)}.photo-uploader .preview img{width:100%;height:100%;object-fit:cover;border-radius:var(--radius-md)}.photo-uploader .preview svg{width:40px;height:40px;stroke-width:1.5}.history-log ul{font-size:.8rem;max-height:120px;overflow-y:auto;background:var(--bg-alt);border-radius:var(--radius-md);padding:.75rem}.list{list-style:none;margin:0;padding:0;display:grid;gap:.75rem}.list li{padding:.75rem 1rem;border-radius:var(--radius-md);background:var(--bg-alt);display:flex;justify-content:space-between;align-items:center;gap:.75rem}.dark-theme .list li{background:rgba(148,163,184,.14)}#app-error-banner{background:var(--danger);color:#fff;padding:1rem;text-align:center;display:none;border-radius:var(--radius-md);margin:0 1.5rem 1.5rem}tbody tr{cursor:pointer}label,input,select,textarea{font-size:.9rem;width:100%}label{display:flex;flex-direction:column;gap:4px}input,select,textarea{border-radius:var(--radius-md);border:1px solid var(--border-strong);padding:.5rem .75rem;background-color:var(--surface)}.badge{padding:4px 8px;border-radius:6px;font-size:.75rem;font-weight:600}.badge.low{background:var(--danger);color:white}.badge.medium{background:var(--warning);color:black}.badge.good{background:var(--success);color:white}.empty-state{color:var(--text-muted);font-style:italic;text-align:center}@media(max-width:768px){.modal-body{grid-template-columns:1fr}thead{display:none}tbody tr{display:block;padding:1rem;border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:1rem}tbody td{display:flex;justify-content:space-between;align-items:center;padding:.25rem 0;border:none}tbody td:before{content:attr(data-label);font-weight:600}}
+    </style>
+</head>
+<body>
+<div id="stock-app-wrapper">
+
+    <div id="app-error-banner"></div>
+
+    <div class="app-shell">
+        <header class="app-header">
+            <div class="header-inner">
+                <div class="brand">
+                    <h1>Gestion des Stocks</h1>
+                    <p>Visualisez et ajustez vos stocks instantanément.</p>
+                </div>
+                <div class="header-actions" id="header-actions">
+                    <button id="theme-toggle" class="icon-button" type="button" aria-label="Basculer le thème">🌙</button>
+                    <button class="btn-primary" type="button" onclick="App.openModal()">+ Nouveau produit</button>
+                </div>
+            </div>
+        </header>
+
+        <main class="main-content" id="main-content" style="display:none;">
+            <div class="content-max">
+                <nav class="sempa-tabs" aria-label="Navigation principale">
+                    <button class="sempa-tab active" type="button" data-tab="overview">Vue globale</button>
+                    <button class="sempa-tab" type="button" data-tab="inventory">Inventaire</button>
+                    <button class="sempa-tab" type="button" data-tab="movements">Mouvements</button>
+                    <button class="sempa-tab" type="button" data-tab="categories">Catégories</button>
+                </nav>
+
+                <section class="sempa-content active" id="overview">
+                     <div class="metrics-grid">
+                        <article class="metric-card"><div class="metric-label">Produits actifs</div><div class="metric-value" id="total-products">0</div></article>
+                        <article class="metric-card"><div class="metric-label">Alertes de stock</div><div class="metric-value" id="alerts-count">0</div></article>
+                        <article class="metric-card"><div class="metric-label">Unités disponibles</div><div class="metric-value" id="total-units">0</div></article>
+                        <article class="metric-card"><div class="metric-label">Valeur estimée</div><div class="metric-value" id="total-value">0 €</div></article>
+                    </div>
+                    <div class="section-heading" style="margin-top:2rem;"><h2>Analyse des Mouvements</h2></div>
+                    <div class="dashboard-grid cols-2">
+                        <div class="card">
+                            <h3><span style="color:var(--success)">●</span> Top 5 des Sorties (30 derniers jours)</h3>
+                            <ul class="list" id="best-sellers"><li class="empty-state">Chargement...</li></ul>
+                        </div>
+                         <div class="card">
+                            <h3><span style="color:var(--warning)">●</span> Produits dormants (Aucune sortie > 90j)</h3>
+                            <ul class="list" id="slow-movers"><li class="empty-state">Chargement...</li></ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="sempa-content" id="inventory">
+                    <div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;margin-bottom:1.5rem;">
+                        <h2>Inventaire détaillé</h2>
+                        <button class="btn-ghost" type="button" onclick="App.exportInventory()">Exporter l'inventaire</button>
+                    </div>
+                    <div style="display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin-bottom:1.5rem;">
+                        <input type="search" id="product-search" class="search-input" placeholder="Rechercher par nom ou référence..." autocomplete="off">
+                        <select id="filter-category" class="select"><option value="">Toutes les catégories</option></select>
+                        <select id="filter-status" class="select"><option value="">Tous les statuts</option><option value="low">Critique</option><option value="medium">À surveiller</option><option value="good">Stable</option></select>
+                    </div>
+                    <div class="table-wrapper">
+                        <table>
+                            <thead><tr><th>Photo</th><th>Produit</th><th>Référence</th><th>Stock</th><th>Seuil</th><th>Statut</th><th>Valeur</th><th>Actions</th></tr></thead>
+                            <tbody id="products-table"></tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section class="sempa-content" id="movements">
+                     <div class="section-heading"><h2>Suivi des mouvements</h2><p class="text-muted">Consignez chaque entrée, sortie ou ajustement.</p></div>
+                    <div class="dashboard-grid cols-2">
+                        <div class="card">
+                            <h3>Enregistrer un mouvement</h3>
+                            <form id="movement-form" style="display:grid;gap:1rem;">
+                                <label>Produit<select id="movement-product" class="select" required><option value="">Sélectionner un produit</option></select></label>
+                                <label>Type<select id="movement-type" class="select"><option value="in">Entrée</option><option value="out">Sortie</option><option value="adjust">Ajustement</option></select></label>
+                                <label>Quantité<input type="number" id="movement-quantity" min="1" value="1" required></label>
+                                <label>Raison<input type="text" id="movement-reason" placeholder="Ex: Réception commande, Vente..." required></label>
+                                <button class="btn-primary" type="submit" style="margin-top:1rem">Valider le mouvement</button>
+                            </form>
+                        </div>
+                        <div class="card">
+                            <h3>Historique récent</h3>
+                            <div class="table-wrapper" style="box-shadow:none;border-radius:var(--radius-md);">
+                                <table><thead><tr><th>Date</th><th>Produit</th><th>Type</th><th>Quantité</th><th>Raison</th></tr></thead><tbody id="movements-table"></tbody></table>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="sempa-content" id="categories">
+                     <div class="section-heading"><h2>Gérer les catégories</h2></div>
+                    <div class="dashboard-grid cols-2">
+                        <div class="card">
+                            <h3>Ajouter une catégorie</h3>
+                            <form id="add-category-form" style="display:flex;gap:12px">
+                                <label style="margin:0;flex:1">Nom<input type="text" id="new-category-name" required placeholder="Ex: Visserie"></label>
+                                <button class="btn-primary" type="submit" style="align-self:end">Ajouter</button>
+                            </form>
+                        </div>
+                        <div class="card">
+                            <h3>Catégories existantes</h3>
+                            <ul class="list" id="categories-list"></ul>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+
+    <div class="modal-backdrop" id="product-modal">
+        <div class="modal-panel">
+            <div class="modal-header"><h2 id="modal-title">Fiche Produit</h2><button type="button" class="btn-ghost" onclick="App.closeModal()">×</button></div>
+            <div class="modal-body">
+                <div class="left-column">
+                    <div class="photo-uploader">
+                        <div id="product-image-preview" class="preview"></div>
+                        <label for="product-image-upload" id="photo-upload-label" class="btn-ghost" style="width:100%;text-align:center;cursor:pointer">Ajouter une photo</label>
+                        <input type="file" id="product-image-upload" accept="image/*" style="display:none">
+                    </div>
+                    <div class="history-log" id="product-history">
+                        <h4>Historique</h4><ul id="product-history-log"><li class="empty-state">Aucun historique.</li></ul>
+                    </div>
+                </div>
+                <div class="right-column">
+                    <form id="product-form" style="display:grid;gap:1rem">
+                        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+                            <label>Nom du produit<input type="text" id="product-name" required></label>
+                            <label>Référence<input type="text" id="product-reference"></label>
+                        </div>
+                        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+                            <label>Stock actuel<input type="number" id="product-stock" min="0"></label>
+                            <label>Seuil d'alerte<input type="number" id="product-minstock" min="0"></label>
+                        </div>
+                        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+                            <label>Prix d'achat (€ HT)<input type="number" id="product-purchase-price" min="0" step="0.01"></label>
+                            <label>Prix de vente (€ HT)<input type="number" id="product-sale-price" min="0" step="0.01"></label>
+                        </div>
+                        <label>Catégorie<select id="product-category" class="select"></select></label>
+                        <label>Description<textarea id="product-desc" rows="2"></textarea></label>
+                        <div style="border-top:1px solid var(--border);padding-top:1rem">
+                            <label style="flex-direction:row;align-items:center;gap:8px;cursor:pointer">
+                                <input type="checkbox" id="product-is-kit">Ce produit est un kit
+                            </label>
+                            <div id="kit-components-section" style="display:none;margin-top:1rem;gap:12px">
+                                <h4>Composants du kit</h4>
+                                <input type="search" id="kit-component-search" class="search-input" placeholder="Rechercher un composant...">
+                                <ul id="kit-component-search-results" class="list" style="max-height:120px;overflow-y:auto;background:var(--surface-alt)"></ul>
+                                <ul id="kit-components-list" class="list"></ul>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button class="btn-ghost" type="button" onclick="App.closeModal()">Annuler</button>
+                <button class="btn-primary" type="button" onclick="App.saveProduct()">Enregistrer</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    const App = (() => {
+        'use strict';
+        const WP_API_ROOT = (window.wpApiSettings?.root ?? `${window.location.origin}/wp-json`).replace(/\/$/, '');
+        const API_BASE = `${WP_API_ROOT}/sempa-stocks/v1`;
+        const API_ENDPOINTS = {
+            products: (id = null) => id ? `${API_BASE}/products/${id}` : `${API_BASE}/products`,
+            photo: (id) => `${API_BASE}/products/${id}/photo`,
+            history: (id) => `${API_BASE}/products/${id}/history`,
+            movements: () => `${API_BASE}/movements`,
+            categories: (id = null) => id ? `${API_BASE}/categories/${id}` : `${API_BASE}/categories`,
+        };
+        const PLACEHOLDER_SVG = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5'><path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4'/><polyline points='17 8 12 3 7 8'/><line x1='12' y1='3' x2='12' y2='15'/></svg>`;
+        const STATUS_LABELS = { low: 'Critique', medium: 'À surveiller', good: 'Stable' };
+        
+        let state = { products: [], movements: [], categories: [], currentProductId: null, currentKitComponents: [] };
+        
+        async function fetchJson(url, options = {}) {
+            const fetchOptions = {
+                credentials: 'same-origin',
+                ...options,
+            };
+            const headers = { Accept: 'application/json', ...(options.headers || {}) };
+            if (fetchOptions.body && !(fetchOptions.body instanceof FormData)) {
+                headers['Content-Type'] = 'application/json';
+            }
+            if (typeof wpApiSettings !== 'undefined' && wpApiSettings.nonce) {
+                headers['X-WP-Nonce'] = wpApiSettings.nonce;
+            }
+            fetchOptions.headers = headers;
+
+            try {
+                const response = await fetch(url, fetchOptions);
+                const text = await response.text();
+                let payload;
+                try {
+                    payload = text ? JSON.parse(text) : {};
+                } catch(e) {
+                    throw new Error("Réponse invalide du serveur.");
+                }
+
+                if (!response.ok) {
+                    let message = "Une erreur est survenue.";
+                    if (response.status === 403) message = "Permissions insuffisantes. Le rôle 'Éditeur' est requis.";
+                    else if (payload && payload.message) message = payload.message.replace(/<[^>]*>?/gm, '');
+                    throw new Error(message);
+                }
+                return payload;
+            } catch (error) {
+                console.error('Erreur API:', error);
+                throw error;
+            }
+        }
+
+        async function loadInitialData() {
+            try {
+                const [productsData, movementsData, categoriesData] = await Promise.all([
+                    fetchJson(API_ENDPOINTS.products()),
+                    fetchJson(API_ENDPOINTS.movements()),
+                    fetchJson(API_ENDPOINTS.categories())
+                ]);
+                state.products = (productsData.products || []).map(p => ({...p, id: Number(p.id)}));
+                state.movements = movementsData.movements || [];
+                state.categories = categoriesData || [];
+                document.getElementById('app-error-banner').style.display = 'none';
+                document.getElementById('main-content').style.display = 'block';
+            } catch (error) {
+                document.getElementById('app-error-banner').textContent = `Erreur de chargement : ${error.message}`;
+                document.getElementById('app-error-banner').style.display = 'block';
+            }
+        }
+        
+        async function refreshData() {
+            await loadInitialData();
+            renderAll();
+        }
+
+        function renderAll() {
+            renderProducts();
+            renderCategories();
+            renderMovements();
+            renderDashboard();
+            renderAdvancedDashboard();
+        }
+        
+        function getCategoryName(slug) {
+            const category = state.categories.find(c => c.slug === slug);
+            return category ? category.name : (slug || 'Sans catégorie');
+        }
+
+        function getStockStatus(stock, minStock) {
+            if (stock <= 0) return 'low';
+            if (stock <= minStock) return 'medium';
+            return 'good';
+        }
+
+        function formatCurrency(amount) {
+            return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(amount || 0);
+        }
+
+        function getFilteredProducts() {
+            const searchTerm = (document.getElementById('product-search')?.value || '').toLowerCase();
+            const categoryFilter = document.getElementById('filter-category')?.value || '';
+            const statusFilter = document.getElementById('filter-status')?.value || '';
+
+            return state.products.filter(p => {
+                const matchesSearch = p.name.toLowerCase().includes(searchTerm) ||
+                                    (p.reference && p.reference.toLowerCase().includes(searchTerm));
+                const matchesCategory = !categoryFilter || p.category === categoryFilter;
+                const productStatus = !p.is_kit ? getStockStatus(p.stock, p.minStock) : 'good';
+                const matchesStatus = !statusFilter || productStatus === statusFilter;
+
+                return matchesSearch && matchesCategory && matchesStatus;
+            });
+        }
+
+        function renderProducts() {
+            const tableBody = document.getElementById('products-table');
+            if(!tableBody) return;
+            const productsToDisplay = getFilteredProducts().sort((a, b) => a.name.localeCompare(b.name, 'fr'));
+            tableBody.innerHTML = productsToDisplay.map(p => {
+                const status = !p.is_kit ? getStockStatus(p.stock, p.minStock) : 'good';
+                return `
+                <tr onclick="App.openModal(${p.id})">
+                    <td data-label="Photo"><img src="${p.imageUrl || ''}" class="product-thumbnail" alt="${p.name}" onerror="this.style.display='none'"></td>
+                    <td data-label="Produit">${p.name}${p.is_kit ? ' (Kit)' : ''}</td>
+                    <td data-label="Référence">${p.reference || '—'}</td>
+                    <td data-label="Stock">${p.is_kit ? 'N/A' : p.stock}</td>
+                    <td data-label="Seuil">${p.minStock}</td>
+                    <td data-label="Statut">${!p.is_kit ? `<span class="badge ${status}">${STATUS_LABELS[status]}</span>` : 'N/A'}</td>
+                    <td data-label="Valeur">${formatCurrency(p.salePrice * p.stock)}</td>
+                    <td class="table-actions" onclick="event.stopPropagation()">
+                        <button class="btn-danger" type="button" onclick="App.deleteProduct(${p.id})">Supprimer</button>
+                    </td>
+                </tr>`;
+            }).join('');
+        }
+        
+        function renderCategories() {
+            const list = document.getElementById('categories-list');
+            const selects = document.querySelectorAll('#product-category, #filter-category');
+            if (!list || !selects.length) return;
+            const optionsHTML = state.categories.map(c => `<option value="${c.slug}">${c.name}</option>`).join('');
+            selects.forEach(select => {
+                const currentVal = select.value;
+                select.innerHTML = (select.id === 'filter-category' ? '<option value="">Toutes les catégories</option>' : '') + optionsHTML;
+                if(currentVal) select.value = currentVal;
+            });
+            list.innerHTML = state.categories.map(c => `<li><span>${c.name}</span><button class="btn-danger" type="button" onclick="App.deleteCategory(${c.id})">X</button></li>`).join('') || '<li class="empty-state">Aucune catégorie.</li>';
+        }
+
+        function renderMovements() {
+            const tableBody = document.getElementById('movements-table');
+            const movementSelect = document.getElementById('movement-product');
+            if(!tableBody || !movementSelect) return;
+            tableBody.innerHTML = state.movements.slice(0, 50).map(m => {
+                const quantityDisplay = m.type === 'in' ? `+${m.quantity}` : m.type === 'out' ? `-${m.quantity}` : `${m.quantity}`;
+                return `<tr><td>${new Date(m.date).toLocaleDateString('fr-FR')}</td><td>${m.productName}</td><td>${m.type === 'in' ? 'Entrée' : m.type === 'out' ? 'Sortie' : 'Ajustement'}</td><td>${quantityDisplay}</td><td>${m.reason || '-'}</td></tr>`;
+            }).join('');
+            movementSelect.innerHTML = '<option value="">Sélectionner un produit</option>' + state.products.filter(p => !p.is_kit).sort((a,b)=>a.name.localeCompare(b.name, 'fr')).map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+        }
+        
+        function renderDashboard() {
+            const totalProducts = state.products.length;
+            const totalUnits = state.products.filter(p => !p.is_kit).reduce((sum, p) => sum + p.stock, 0);
+            const totalValue = state.products.filter(p => !p.is_kit).reduce((sum, p) => sum + (p.salePrice * p.stock), 0);
+            const alertsCount = state.products.filter(p => !p.is_kit && p.stock <= p.minStock).length;
+
+            document.getElementById('total-products').textContent = totalProducts;
+            document.getElementById('total-units').textContent = totalUnits;
+            document.getElementById('total-value').textContent = formatCurrency(totalValue);
+            document.getElementById('alerts-count').textContent = alertsCount;
+        }
+
+        function renderAdvancedDashboard() {
+            const thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+            
+            const recentMovements = state.movements.filter(m => new Date(m.date) >= thirtyDaysAgo && m.type === 'out');
+            const productOutCount = {};
+            
+            recentMovements.forEach(m => {
+                productOutCount[m.productId] = (productOutCount[m.productId] || 0) + m.quantity;
+            });
+            
+            const bestSellers = Object.entries(productOutCount)
+                .sort(([,a], [,b]) => b - a)
+                .slice(0, 5)
+                .map(([productId, count]) => {
+                    const product = state.products.find(p => p.id == productId);
+                    return product ? { name: product.name, count } : null;
+                })
+                .filter(Boolean);
+            
+            const bestSellersList = document.getElementById('best-sellers');
+            bestSellersList.innerHTML = bestSellers.length ? 
+                bestSellers.map(p => `<li><span>${p.name}</span><strong>${p.count} unités</strong></li>`).join('') :
+                '<li class="empty-state">Aucune sortie récente</li>';
+
+            const ninetyDaysAgo = new Date();
+            ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+            
+            const slowMovers = state.products.filter(p => {
+                if (p.is_kit) return false;
+                const lastMovement = state.movements
+                    .filter(m => m.productId === p.id && m.type === 'out')
+                    .sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+                
+                return !lastMovement || new Date(lastMovement.date) < ninetyDaysAgo;
+            }).slice(0, 10);
+            
+            const slowMoversList = document.getElementById('slow-movers');
+            slowMoversList.innerHTML = slowMovers.length ?
+                slowMovers.map(p => `<li><span>${p.name}</span><small>Stock: ${p.stock}</small></li>`).join('') :
+                '<li class="empty-state">Aucun produit dormant</li>';
+        }
+
+        async function openModal(productId = null) {
+            const modal = document.getElementById('product-modal');
+            document.getElementById('product-form').reset();
+            state.currentProductId = productId;
+            state.currentKitComponents = [];
+            
+            const product = productId ? await fetchJson(API_ENDPOINTS.products(productId)) : null;
+            const preview = document.getElementById('product-image-preview');
+            const label = document.getElementById('photo-upload-label');
+            
+            if (product) {
+                document.getElementById('product-name').value = product.name;
+                document.getElementById('product-reference').value = product.reference;
+                document.getElementById('product-stock').value = product.stock;
+                document.getElementById('product-minstock').value = product.minStock;
+                document.getElementById('product-purchase-price').value = product.purchasePrice;
+                document.getElementById('product-sale-price').value = product.salePrice;
+                document.getElementById('product-category').value = product.category;
+                document.getElementById('product-desc').value = product.description;
+                document.getElementById('product-is-kit').checked = product.is_kit;
+                
+                preview.innerHTML = product.imageUrl ? `<img src="${product.imageUrl}" alt="Aperçu">` : PLACEHOLDER_SVG;
+                label.textContent = product.imageUrl ? "Changer la photo" : "Ajouter une photo";
+                state.currentKitComponents = product.components || [];
+                fetchAndDisplayHistory(productId);
+            } else {
+                 preview.innerHTML = PLACEHOLDER_SVG;
+                 label.textContent = "Ajouter une photo";
+                 document.getElementById('product-history-log').innerHTML = '<li class="empty-state">Aucun historique.</li>';
+            }
+
+            toggleKitSection();
+            renderKitComponents();
+            modal.classList.add('open');
+        }
+
+        function closeModal() { 
+            document.getElementById('product-modal').classList.remove('open'); 
+        }
+
+        async function fetchAndDisplayHistory(productId) {
+             const historyLog = document.getElementById('product-history-log');
+            if(!historyLog) return;
+            try {
+                const history = await fetchJson(API_ENDPOINTS.history(productId));
+                historyLog.innerHTML = history.length ? history.map(h => `<li>${h.action}<small>${new Date(h.timestamp).toLocaleString('fr-FR')} par ${h.user_name}</small></li>`).join('') : '<li class="empty-state">Aucun historique.</li>';
+            } catch (error) { historyLog.innerHTML = '<li class="empty-state">Erreur chargement.</li>'; }
+        }
+
+        async function saveProduct() {
+            const form = document.getElementById('product-form');
+            const payload = {
+                name: form.querySelector('#product-name').value.trim(),
+                reference: form.querySelector('#product-reference').value.trim(),
+                stock: parseInt(form.querySelector('#product-stock').value, 10) || 0,
+                minStock: parseInt(form.querySelector('#product-minstock').value, 10) || 1,
+                purchasePrice: parseFloat(form.querySelector('#product-purchase-price').value) || 0,
+                salePrice: parseFloat(form.querySelector('#product-sale-price').value) || 0,
+                category: form.querySelector('#product-category').value,
+                description: form.querySelector('#product-desc').value.trim(),
+                is_kit: form.querySelector('#product-is-kit').checked,
+                components: state.currentKitComponents,
+            };
+            if (!payload.name) return alert('Le nom du produit est obligatoire.');
+
+            const isUpdate = Boolean(state.currentProductId);
+            const url = isUpdate ? API_ENDPOINTS.products(state.currentProductId) : API_ENDPOINTS.products();
+            const method = isUpdate ? 'PUT' : 'POST';
+
+            try {
+                const savedProduct = await fetchJson(url, { method, body: JSON.stringify(payload) });
+                const newProductId = savedProduct.id || state.currentProductId;
+                const photoFile = document.getElementById('product-image-upload').files[0];
+                if (photoFile && newProductId) {
+                    await uploadPhoto(newProductId, photoFile);
+                }
+                await refreshData();
+                closeModal();
+            } catch (error) { alert("Erreur: " + error.message); }
+        }
+        
+        async function uploadPhoto(productId, file) {
+            const formData = new FormData();
+            formData.append('file', file);
+            try {
+                await fetchJson(API_ENDPOINTS.photo(productId), { method: 'POST', body: formData });
+            } catch (error) {
+                alert("La photo n'a pas pu être envoyée : " + error.message);
+            }
+        }
+
+        async function deleteProduct(productId) {
+            if (!confirm(`Voulez-vous vraiment supprimer ce produit ?`)) return;
+            try {
+                await fetchJson(API_ENDPOINTS.products(productId), { method: 'DELETE' });
+                await refreshData();
+            } catch (error) { alert("Erreur: " + error.message); }
+        }
+
+        function toggleKitSection() {
+            const isKit = document.getElementById('product-is-kit').checked;
+            const kitSection = document.getElementById('kit-components-section');
+            kitSection.style.display = isKit ? 'grid' : 'none';
+        }
+
+        function handleComponentSearch(e) {
+            const searchTerm = e.target.value.toLowerCase();
+            const resultsContainer = document.getElementById('kit-component-search-results');
+            
+            if (searchTerm.length < 2) {
+                resultsContainer.innerHTML = '';
+                return;
+            }
+            
+            const filtered = state.products.filter(p => 
+                !p.is_kit && 
+                p.name.toLowerCase().includes(searchTerm) &&
+                !state.currentKitComponents.some(comp => comp.id === p.id)
+            );
+            
+            resultsContainer.innerHTML = filtered.map(p => 
+                `<li onclick="App.addComponentToKit(${p.id})" style="cursor:pointer">${p.name} (${p.reference || 'Sans référence'})</li>`
+            ).join('') || '<li class="empty-state">Aucun produit trouvé</li>';
+        }
+
+        function addComponentToKit(productId) {
+            const product = state.products.find(p => p.id === productId);
+            if (product && !state.currentKitComponents.some(comp => comp.id === productId)) {
+                state.currentKitComponents.push({
+                    id: productId,
+                    name: product.name,
+                    reference: product.reference,
+                    quantity: 1
+                });
+                renderKitComponents();
+            }
+            document.getElementById('kit-component-search').value = '';
+            document.getElementById('kit-component-search-results').innerHTML = '';
+        }
+
+        function renderKitComponents() {
+            const list = document.getElementById('kit-components-list');
+            list.innerHTML = state.currentKitComponents.map(comp => `
+                <li>
+                    <span>${comp.name} (${comp.reference || 'Sans référence'})</span>
+                    <div style="display:flex;gap:8px;align-items:center">
+                        <input type="number" value="${comp.quantity}" min="1" 
+                               onchange="App.updateComponentQuantity(${comp.id}, this.value)" 
+                               style="width:60px">
+                        <button class="btn-danger" onclick="App.removeComponent(${comp.id})">×</button>
+                    </div>
+                </li>
+            `).join('') || '<li class="empty-state">Aucun composant ajouté</li>';
+        }
+
+        function updateComponentQuantity(componentId, quantity) {
+            const comp = state.currentKitComponents.find(c => c.id === componentId);
+            if (comp) {
+                comp.quantity = parseInt(quantity) || 1;
+            }
+        }
+
+        function removeComponent(componentId) {
+            state.currentKitComponents = state.currentKitComponents.filter(c => c.id !== componentId);
+            renderKitComponents();
+        }
+
+        async function addCategory(e) {
+            e.preventDefault();
+            const nameInput = document.getElementById('new-category-name');
+            const name = nameInput.value.trim();
+            
+            if (!name) return;
+            
+            try {
+                await fetchJson(API_ENDPOINTS.categories(), {
+                    method: 'POST',
+                    body: JSON.stringify({ name })
+                });
+                nameInput.value = '';
+                await refreshData();
+            } catch (error) {
+                alert("Erreur: " + error.message);
+            }
+        }
+
+        async function deleteCategory(categoryId) {
+            if (!confirm('Supprimer cette catégorie ?')) return;
+            
+            try {
+                await fetchJson(API_ENDPOINTS.categories(categoryId), { method: 'DELETE' });
+                await refreshData();
+            } catch (error) {
+                alert("Erreur: " + error.message);
+            }
+        }
+
+        async function addStockMovement(e) {
+            e.preventDefault();
+            const form = e.target;
+            const productId = document.getElementById('movement-product').value;
+            const type = document.getElementById('movement-type').value;
+            const quantity = document.getElementById('movement-quantity').value;
+            const reason = document.getElementById('movement-reason').value;
+            
+            if (!productId || !quantity || !reason) {
+                alert('Veuillez remplir tous les champs');
+                return;
+            }
+            
+            const product = state.products.find(p => p.id == productId);
+            if (!product) return;
+            
+            try {
+                await fetchJson(API_ENDPOINTS.movements(), {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        productId: parseInt(productId),
+                        productName: product.name,
+                        type: type,
+                        quantity: parseInt(quantity),
+                        reason: reason
+                    })
+                });
+                
+                form.reset();
+                await refreshData();
+            } catch (error) {
+                alert("Erreur: " + error.message);
+            }
+        }
+
+        function filterProducts() {
+            renderProducts();
+        }
+
+        function exportInventory() {
+            const csvContent = [
+                ['Nom', 'Référence', 'Stock', 'Seuil', 'Statut', 'Prix Achat', 'Prix Vente', 'Valeur Stock', 'Catégorie'],
+                ...state.products.map(p => [
+                    p.name + (p.is_kit ? ' (Kit)' : ''),
+                    p.reference || '',
+                    p.is_kit ? 'N/A' : p.stock,
+                    p.minStock,
+                    p.is_kit ? 'N/A' : STATUS_LABELS[getStockStatus(p.stock, p.minStock)],
+                    p.purchasePrice,
+                    p.salePrice,
+                    p.is_kit ? 0 : p.salePrice * p.stock,
+                    getCategoryName(p.category)
+                ])
+            ].map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
+            
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const link = document.createElement('a');
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', `inventaire_sempa_${new Date().toISOString().split('T')[0]}.csv`);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+
+        function applyTheme(theme) {
+            const wrapper = document.getElementById('stock-app-wrapper');
+            const toggle = document.getElementById('theme-toggle');
+            
+            if (theme === 'dark') {
+                wrapper.classList.add('dark-theme');
+                toggle.innerHTML = '☀️';
+                localStorage.setItem('sempa_theme', 'dark');
+            } else {
+                wrapper.classList.remove('dark-theme');
+                toggle.innerHTML = '🌙';
+                localStorage.setItem('sempa_theme', 'light');
+            }
+        }
+
+        function bindEvents() {
+            document.getElementById('theme-toggle')?.addEventListener('click', () => applyTheme(document.getElementById('stock-app-wrapper').classList.contains('dark-theme') ? 'light' : 'dark'));
+            document.querySelectorAll('.sempa-tab').forEach(tab => tab.addEventListener('click', (e) => {
+                document.querySelector('.sempa-tab.active')?.classList.remove('active');
+                document.querySelector('.sempa-content.active')?.classList.remove('active');
+                e.currentTarget.classList.add('active');
+                document.getElementById(e.currentTarget.dataset.tab)?.classList.add('active');
+            }));
+            
+            const addCategoryForm = document.getElementById('add-category-form');
+            if(addCategoryForm) addCategoryForm.addEventListener('submit', addCategory);
+            
+            const movementForm = document.getElementById('movement-form');
+            if(movementForm) movementForm.addEventListener('submit', addStockMovement);
+            
+            const productSearch = document.getElementById('product-search');
+            if(productSearch) productSearch.addEventListener('input', filterProducts);
+            
+            const categoryFilter = document.getElementById('filter-category');
+            if(categoryFilter) categoryFilter.addEventListener('change', filterProducts);
+            
+            const statusFilter = document.getElementById('filter-status');
+            if(statusFilter) statusFilter.addEventListener('change', filterProducts);
+            
+            document.getElementById('product-is-kit')?.addEventListener('change', toggleKitSection);
+            document.getElementById('kit-component-search')?.addEventListener('input', handleComponentSearch);
+            
+            document.getElementById('product-image-upload')?.addEventListener('change', function(e) {
+                const file = e.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = function(e) {
+                        document.getElementById('product-image-preview').innerHTML = `<img src="${e.target.result}" alt="Aperçu">`;
+                        document.getElementById('photo-upload-label').textContent = "Changer la photo";
+                    };
+                    reader.readAsDataURL(file);
+                }
+            });
+        }
+
+        async function init() {
+            bindEvents();
+            await loadInitialData();
+            renderAll();
+            applyTheme(localStorage.getItem('sempa_theme') || 'light');
+        }
+
+        return { 
+            init, openModal, closeModal, saveProduct, deleteProduct, 
+            addCategory, deleteCategory, removeComponent, exportInventory,
+            updateComponentQuantity, addComponentToKit, handleComponentSearch
+        };
+    })();
+
+    document.addEventListener('DOMContentLoaded', App.init);
+</script>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -9,7 +9,7 @@ function uncode_language_setup()
 
 function theme_enqueue_styles()
 {
-    $production_mode = ot_get_option('_uncode_production');
+    $production_mode = function_exists('ot_get_option') ? ot_get_option('_uncode_production') : 'off';
     $resources_version = ($production_mode === 'on') ? null : rand();
     if ( function_exists('get_rocket_option') && ( get_rocket_option( 'remove_query_strings' ) || get_rocket_option( 'minify_css' ) || get_rocket_option( 'minify_js' ) ) ) {
         $resources_version = null;
@@ -144,209 +144,371 @@ require_once(ABSPATH . 'wp-admin/includes/media.php');
 
 add_action('rest_api_init', function () {
     $namespace = 'sempa-stocks/v1';
-    register_rest_route($namespace, '/products(?:/(?P<id>\d+))?', array(
-        array('methods' => 'GET', 'callback' => 'sempa_get_products_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'POST', 'callback' => 'sempa_save_product_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'PUT', 'callback' => 'sempa_save_product_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'DELETE', 'callback' => 'sempa_delete_product_callback', 'permission_callback' => 'sempa_check_api_permission'),
+
+    register_rest_route($namespace, '/products', array(
+        array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => 'sempa_get_products_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+        array(
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => 'sempa_save_product_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
     ));
-    register_rest_route($namespace, '/products/(?P<id>\d+)/photo', array('methods' => 'POST', 'callback' => 'sempa_upload_photo_callback', 'permission_callback' => 'sempa_check_api_permission'));
-    register_rest_route($namespace, '/products/(?P<id>\d+)/history', array('methods' => 'GET', 'callback' => 'sempa_get_history_callback', 'permission_callback' => 'sempa_check_api_permission'));
+
+    register_rest_route($namespace, '/products/(?P<id>\d+)', array(
+        'args' => array(
+            'id' => array(
+                'validate_callback' => 'sempa_validate_positive_int',
+            ),
+        ),
+        array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => 'sempa_get_products_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+        array(
+            'methods' => WP_REST_Server::EDITABLE,
+            'callback' => 'sempa_save_product_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+        array(
+            'methods' => WP_REST_Server::DELETABLE,
+            'callback' => 'sempa_delete_product_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+    ));
+
+    register_rest_route($namespace, '/products/(?P<id>\d+)/photo', array(
+        'methods' => WP_REST_Server::CREATABLE,
+        'callback' => 'sempa_upload_photo_callback',
+        'permission_callback' => 'sempa_check_api_permission',
+        'args' => array(
+            'id' => array('validate_callback' => 'sempa_validate_positive_int'),
+        ),
+    ));
+
+    register_rest_route($namespace, '/products/(?P<id>\d+)/history', array(
+        'methods' => WP_REST_Server::READABLE,
+        'callback' => 'sempa_get_history_callback',
+        'permission_callback' => 'sempa_check_api_permission',
+        'args' => array(
+            'id' => array('validate_callback' => 'sempa_validate_positive_int'),
+        ),
+    ));
+
     register_rest_route($namespace, '/movements', array(
-        array('methods' => 'GET', 'callback' => 'sempa_get_movements_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'POST', 'callback' => 'sempa_create_movement_callback', 'permission_callback' => 'sempa_check_api_permission'),
+        array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => 'sempa_get_movements_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+        array(
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => 'sempa_create_movement_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
     ));
-    register_rest_route($namespace, '/categories(?:/(?P<id>\d+))?', array(
-        array('methods' => 'GET', 'callback' => 'sempa_get_categories_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'POST', 'callback' => 'sempa_create_category_callback', 'permission_callback' => 'sempa_check_api_permission'),
-        array('methods' => 'DELETE', 'callback' => 'sempa_delete_category_callback', 'permission_callback' => 'sempa_check_api_permission'),
+
+    register_rest_route($namespace, '/categories', array(
+        array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => 'sempa_get_categories_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+        array(
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => 'sempa_create_category_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
+    ));
+
+    register_rest_route($namespace, '/categories/(?P<id>\d+)', array(
+        'args' => array(
+            'id' => array('validate_callback' => 'sempa_validate_positive_int'),
+        ),
+        array(
+            'methods' => WP_REST_Server::DELETABLE,
+            'callback' => 'sempa_delete_category_callback',
+            'permission_callback' => 'sempa_check_api_permission',
+        ),
     ));
 });
 
-function sempa_check_api_permission() { 
-    return current_user_can('edit_posts'); 
+function sempa_validate_positive_int($param) {
+    return is_numeric($param) && intval($param) > 0;
+}
+
+function sempa_check_api_permission() {
+    if (!is_user_logged_in()) {
+        return new WP_Error('rest_forbidden', __('Authentification requise.', 'sempa'), array('status' => 401));
+    }
+
+    if (!current_user_can('edit_posts')) {
+        return new WP_Error('rest_forbidden', __('Permissions insuffisantes.', 'sempa'), array('status' => 403));
+    }
+
+    return true;
+}
+
+function sempa_normalize_product(array $product) {
+    $product['id'] = isset($product['id']) ? intval($product['id']) : 0;
+    $product['stock'] = isset($product['stock']) ? intval($product['stock']) : 0;
+    $product['minStock'] = isset($product['minStock']) ? intval($product['minStock']) : 0;
+    $product['purchasePrice'] = isset($product['purchasePrice']) ? floatval($product['purchasePrice']) : 0;
+    $product['salePrice'] = isset($product['salePrice']) ? floatval($product['salePrice']) : 0;
+    $product['is_kit'] = !empty($product['is_kit']) ? 1 : 0;
+
+    if (!empty($product['components']) && is_array($product['components'])) {
+        $product['components'] = array_map(function ($component) {
+            return array(
+                'id' => intval($component['id']),
+                'name' => $component['name'],
+                'reference' => $component['reference'],
+                'quantity' => intval($component['quantity']),
+            );
+        }, $product['components']);
+    }
+
+    return $product;
 }
 
 function sempa_get_products_callback(WP_REST_Request $request) {
-    global $wpdb; 
+    global $wpdb;
     $id = $request->get_param('id');
-    
+
     if ($id) {
         $product = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}products WHERE id = %d", $id), ARRAY_A);
-        if ($product && $product['is_kit']) { 
-            $product['components'] = $wpdb->get_results($wpdb->prepare("SELECT p.id, p.name, p.reference, kc.quantity FROM {$wpdb->prefix}kit_components kc JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d", $id)); 
+        if (!$product) {
+            return new WP_Error('not_found', __('Produit introuvable.', 'sempa'), array('status' => 404));
         }
-        return new WP_REST_Response($product, 200);
-    } else {
-        $products = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}products ORDER BY name ASC", ARRAY_A);
-        return new WP_REST_Response(['products' => $products], 200);
+        if (!empty($product['is_kit'])) {
+            $product['components'] = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT p.id, p.name, p.reference, kc.quantity FROM {$wpdb->prefix}kit_components kc " .
+                    "JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d",
+                    $id
+                ),
+                ARRAY_A
+            );
+        }
+
+        return rest_ensure_response(sempa_normalize_product($product));
     }
+
+    $products = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}products ORDER BY name ASC", ARRAY_A);
+    $products = array_map('sempa_normalize_product', $products);
+
+    return rest_ensure_response(array('products' => $products));
 }
 
 function sempa_save_product_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $id = $request->get_param('id'); 
-    $data = $request->get_json_params(); 
-    $current_user = wp_get_current_user(); 
-    $user_name = $current_user->display_name; 
-    $history_log = [];
-    
+    global $wpdb;
+    $id = $request->get_param('id');
+    $data = $request->get_json_params();
+    $current_user = wp_get_current_user();
+    $history_log = array();
+
     $product_data = array(
-        'name' => sanitize_text_field($data['name']), 
-        'reference' => sanitize_text_field($data['reference']), 
-        'stock' => intval($data['stock']), 
-        'minStock' => intval($data['minStock']), 
-        'purchasePrice' => floatval($data['purchasePrice']), 
-        'salePrice' => floatval($data['salePrice']), 
-        'category' => sanitize_text_field($data['category']), 
-        'description' => sanitize_textarea_field($data['description']), 
-        'is_kit' => !empty($data['is_kit']) ? 1 : 0
+        'name' => sanitize_text_field($data['name'] ?? ''),
+        'reference' => sanitize_text_field($data['reference'] ?? ''),
+        'stock' => isset($data['stock']) ? intval($data['stock']) : 0,
+        'minStock' => isset($data['minStock']) ? intval($data['minStock']) : 0,
+        'purchasePrice' => isset($data['purchasePrice']) ? floatval($data['purchasePrice']) : 0,
+        'salePrice' => isset($data['salePrice']) ? floatval($data['salePrice']) : 0,
+        'category' => sanitize_text_field($data['category'] ?? 'autre'),
+        'description' => sanitize_textarea_field($data['description'] ?? ''),
+        'is_kit' => !empty($data['is_kit']) ? 1 : 0,
+        'lastUpdated' => current_time('mysql'),
     );
-    
+
+    $old_product = null;
     if ($id) {
         $old_product = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}products WHERE id = %d", $id), ARRAY_A);
-        if($old_product) { 
-            foreach ($product_data as $key => $value) { 
-                if (isset($old_product[$key]) && $old_product[$key] != $value) { 
-                    $history_log[] = "Le champ '$key' a été changé de '{$old_product[$key]}' à '$value'."; 
-                } 
-            } 
-        }
-        $wpdb->update("{$wpdb->prefix}products", $product_data, array('id' => $id));
-    } else {
-        $wpdb->insert("{$wpdb->prefix}products", $product_data); 
-        $id = $wpdb->insert_id; 
-        $history_log[] = "Produit créé.";
-    }
-    
-    $was_kit = isset($old_product['is_kit']) ? (int) $old_product['is_kit'] : 0;
-    if ($product_data['is_kit']) {
-        if (!$was_kit) {
-            $history_log[] = "Le produit est désormais géré comme un kit.";
+        if (!$old_product) {
+            return new WP_Error('not_found', __('Produit introuvable.', 'sempa'), array('status' => 404));
         }
 
-        $existing_components = $wpdb->get_results($wpdb->prepare("SELECT component_id, quantity FROM {$wpdb->prefix}kit_components WHERE kit_id = %d", $id), ARRAY_A);
-        $existing_map = array();
-        if (is_array($existing_components)) {
-            foreach ($existing_components as $existing_component) {
-                $existing_map[intval($existing_component['component_id'])] = intval($existing_component['quantity']);
+        foreach ($product_data as $key => $value) {
+            if (array_key_exists($key, $old_product) && $old_product[$key] != $value) {
+                $history_log[] = sprintf("Le champ %s a été modifié.", $key);
             }
+        }
+
+        $wpdb->update("{$wpdb->prefix}products", $product_data, array('id' => $id));
+    } else {
+        $wpdb->insert("{$wpdb->prefix}products", $product_data);
+        $id = $wpdb->insert_id;
+        $history_log[] = __('Produit créé.', 'sempa');
+    }
+
+    if (!empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error, array('status' => 500));
+    }
+
+    $was_kit = isset($old_product['is_kit']) ? intval($old_product['is_kit']) : 0;
+    if ($product_data['is_kit']) {
+        if (!$was_kit) {
+            $history_log[] = __('Le produit est désormais géré comme un kit.', 'sempa');
+        }
+
+        $existing_components = $wpdb->get_results(
+            $wpdb->prepare("SELECT component_id, quantity FROM {$wpdb->prefix}kit_components WHERE kit_id = %d", $id),
+            ARRAY_A
+        );
+        $existing_map = array();
+        foreach ($existing_components as $existing_component) {
+            $existing_map[intval($existing_component['component_id'])] = intval($existing_component['quantity']);
         }
 
         $wpdb->delete("{$wpdb->prefix}kit_components", array('kit_id' => $id));
-        $components = $data['components'] ?? [];
 
-        if (!empty($components)) {
-            $new_map = array();
-            foreach ($components as $comp) {
-                $component_id = isset($comp['id']) ? intval($comp['id']) : 0;
-                $component_quantity = isset($comp['quantity']) ? intval($comp['quantity']) : 0;
-
+        $components = array();
+        if (!empty($data['components']) && is_array($data['components'])) {
+            foreach ($data['components'] as $component) {
+                $component_id = isset($component['id']) ? intval($component['id']) : 0;
+                $component_quantity = isset($component['quantity']) ? intval($component['quantity']) : 0;
                 if ($component_id && $component_quantity) {
-                    $new_map[$component_id] = $component_quantity;
+                    $components[$component_id] = $component_quantity;
                 }
             }
+        }
 
-            if ($existing_map !== $new_map) {
-                $history_log[] = "La liste des composants a été modifiée.";
-            }
+        if ($existing_map !== $components) {
+            $history_log[] = __('La composition du kit a été mise à jour.', 'sempa');
+        }
 
-            foreach ($new_map as $component_id => $component_quantity) {
-                $wpdb->insert("{$wpdb->prefix}kit_components", array(
+        foreach ($components as $component_id => $component_quantity) {
+            $wpdb->insert(
+                "{$wpdb->prefix}kit_components",
+                array(
                     'kit_id' => $id,
                     'component_id' => $component_id,
-                    'quantity' => $component_quantity
-                ));
-            }
-        } elseif (!empty($existing_map)) {
-            $history_log[] = "La liste des composants a été modifiée.";
+                    'quantity' => $component_quantity,
+                )
+            );
         }
     } else {
         if ($was_kit) {
-            $history_log[] = "Ce produit n'est plus géré comme un kit.";
+            $history_log[] = __('Ce produit n\'est plus géré comme un kit.', 'sempa');
         }
         $wpdb->delete("{$wpdb->prefix}kit_components", array('kit_id' => $id));
     }
-    
-    if (!empty($history_log)) { 
-        $wpdb->insert("{$wpdb->prefix}product_history", array(
-            'product_id' => $id, 
-            'user_name' => $user_name, 
-            'action' => implode("\n", $history_log),
-            'timestamp' => current_time('mysql')
-        )); 
+
+    if (!empty($history_log)) {
+        $wpdb->insert(
+            "{$wpdb->prefix}product_history",
+            array(
+                'product_id' => $id,
+                'user_name' => $current_user->display_name,
+                'action' => implode("\n", $history_log),
+                'timestamp' => current_time('mysql'),
+            )
+        );
     }
-    
+
+    if (!empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error, array('status' => 500));
+    }
+
     $product = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}products WHERE id = %d", $id), ARRAY_A);
-    return new WP_REST_Response($product, $id ? 200 : 201);
+    if (!empty($product['is_kit'])) {
+        $product['components'] = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT p.id, p.name, p.reference, kc.quantity FROM {$wpdb->prefix}kit_components kc " .
+                "JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d",
+                $id
+            ),
+            ARRAY_A
+        );
+    }
+
+    return rest_ensure_response(sempa_normalize_product($product));
 }
 
 function sempa_upload_photo_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $id = $request->get_param('id'); 
-    $file = $request->get_file_params()['file'];
-    
-    if (empty($file) || !$id) { 
-        return new WP_Error('bad_request', 'Fichier ou ID de produit manquant.', array('status' => 400)); 
+    global $wpdb;
+    $id = intval($request->get_param('id'));
+    $files = $request->get_file_params();
+    $file = isset($files['file']) ? $files['file'] : null;
+
+    if (!$id || empty($file)) {
+        return new WP_Error('bad_request', __('Fichier ou ID de produit manquant.', 'sempa'), array('status' => 400));
     }
-    
-    $attachment_id = media_handle_sideload($file, 0, "Photo du produit $id");
-    if (is_wp_error($attachment_id)) { 
-        return new WP_Error('upload_error', $attachment_id->get_error_message(), array('status' => 500)); 
+
+    $attachment_id = media_handle_sideload($file, 0, sprintf(__('Photo du produit %d', 'sempa'), $id));
+    if (is_wp_error($attachment_id)) {
+        return new WP_Error('upload_error', $attachment_id->get_error_message(), array('status' => 500));
     }
-    
+
     $image_url = wp_get_attachment_url($attachment_id);
-    $wpdb->update("{$wpdb->prefix}products", array('imageUrl' => $image_url), array('id' => $id));
-    
-    $current_user = wp_get_current_user(); 
-    $user_name = $current_user->display_name;
-    $wpdb->insert("{$wpdb->prefix}product_history", array(
-        'product_id' => $id, 
-        'user_name' => $user_name, 
-        'action' => 'La photo du produit a été mise à jour.',
-        'timestamp' => current_time('mysql')
-    ));
-    
-    return new WP_REST_Response(['status' => 'success', 'imageUrl' => $image_url], 200);
+    $wpdb->update("{$wpdb->prefix}products", array('imageUrl' => $image_url, 'lastUpdated' => current_time('mysql')), array('id' => $id));
+
+    $current_user = wp_get_current_user();
+    $wpdb->insert(
+        "{$wpdb->prefix}product_history",
+        array(
+            'product_id' => $id,
+            'user_name' => $current_user->display_name,
+            'action' => __('La photo du produit a été mise à jour.', 'sempa'),
+            'timestamp' => current_time('mysql'),
+        )
+    );
+
+    return rest_ensure_response(array('status' => 'success', 'imageUrl' => $image_url));
 }
 
 function sempa_get_history_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $id = $request->get_param('id');
-    $history = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}product_history WHERE product_id = %d ORDER BY timestamp DESC", $id));
-    return new WP_REST_Response($history, 200);
+    global $wpdb;
+    $id = intval($request->get_param('id'));
+    $history = $wpdb->get_results(
+        $wpdb->prepare("SELECT * FROM {$wpdb->prefix}product_history WHERE product_id = %d ORDER BY timestamp DESC", $id),
+        ARRAY_A
+    );
+
+    return rest_ensure_response($history);
 }
 
 function sempa_delete_product_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $id = $request->get_param('id');
-    if (!$id) { 
-        return new WP_Error('bad_request', 'ID manquant', ['status' => 400]); 
+    global $wpdb;
+    $id = intval($request->get_param('id'));
+    if (!$id) {
+        return new WP_Error('bad_request', __('Identifiant manquant.', 'sempa'), array('status' => 400));
     }
-    
+
     $product = $wpdb->get_row($wpdb->prepare("SELECT name FROM {$wpdb->prefix}products WHERE id = %d", $id));
-    $current_user = wp_get_current_user(); 
-    $user_name = $current_user->display_name;
-    
-    if ($product) { 
-        $wpdb->insert("{$wpdb->prefix}product_history", array(
-            'product_id' => $id, 
-            'user_name' => $user_name, 
-            'action' => "Produit '{$product->name}' supprimé.",
-            'timestamp' => current_time('mysql')
-        )); 
+    if (!$product) {
+        return new WP_Error('not_found', __('Produit introuvable.', 'sempa'), array('status' => 404));
     }
-    
+
+    $current_user = wp_get_current_user();
+    $wpdb->insert(
+        "{$wpdb->prefix}product_history",
+        array(
+            'product_id' => $id,
+            'user_name' => $current_user->display_name,
+            'action' => sprintf(__('Produit "%s" supprimé.', 'sempa'), $product->name),
+            'timestamp' => current_time('mysql'),
+        )
+    );
+
     $wpdb->delete("{$wpdb->prefix}kit_components", array('kit_id' => $id));
     $wpdb->delete("{$wpdb->prefix}products", array('id' => $id));
-    
-    return new WP_REST_Response(['status' => 'success'], 200);
+
+    if (!empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error, array('status' => 500));
+    }
+
+    return rest_ensure_response(array('status' => 'success'));
 }
 
 function sempa_get_movements_callback(WP_REST_Request $request) {
     global $wpdb;
-    $movements = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}movements ORDER BY date DESC LIMIT 300");
-    return new WP_REST_Response(['movements' => $movements], 200);
+    $movements = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}movements ORDER BY date DESC LIMIT 300", ARRAY_A);
+
+    return rest_ensure_response(array('movements' => $movements));
 }
 
 function sempa_create_movement_callback(WP_REST_Request $request) {
@@ -360,24 +522,24 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
     $product_name = isset($data['productName']) ? sanitize_text_field($data['productName']) : '';
 
     if (!$product_id) {
-        return new WP_Error('bad_request', 'Produit introuvable.', array('status' => 400));
+        return new WP_Error('bad_request', __('Produit introuvable.', 'sempa'), array('status' => 400));
     }
 
     if (!in_array($type, array('in', 'out', 'adjust'), true)) {
-        return new WP_Error('bad_request', 'Type de mouvement invalide.', array('status' => 400));
+        return new WP_Error('bad_request', __('Type de mouvement invalide.', 'sempa'), array('status' => 400));
     }
 
     if ($type === 'adjust') {
         if ($quantity < 0) {
-            return new WP_Error('bad_request', 'La quantité doit être positive pour un ajustement.', array('status' => 400));
+            return new WP_Error('bad_request', __('La quantité doit être positive pour un ajustement.', 'sempa'), array('status' => 400));
         }
     } elseif ($quantity <= 0) {
-        return new WP_Error('bad_request', 'La quantité doit être supérieure à zéro.', array('status' => 400));
+        return new WP_Error('bad_request', __('La quantité doit être supérieure à zéro.', 'sempa'), array('status' => 400));
     }
 
     $product = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}products WHERE id = %d", $product_id), ARRAY_A);
     if (!$product) {
-        return new WP_Error('not_found', 'Produit introuvable.', array('status' => 404));
+        return new WP_Error('not_found', __('Produit introuvable.', 'sempa'), array('status' => 404));
     }
 
     $current_stock = intval($product['stock']);
@@ -387,8 +549,8 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
     if ($type === 'in') {
         $new_stock = $current_stock + $quantity;
     } elseif ($type === 'out') {
-        if (!$product['is_kit'] && $quantity > $current_stock) {
-            return new WP_Error('insufficient_stock', 'Stock insuffisant pour effectuer la sortie.', array('status' => 400));
+        if (empty($product['is_kit']) && $quantity > $current_stock) {
+            return new WP_Error('insufficient_stock', __('Stock insuffisant pour effectuer la sortie.', 'sempa'), array('status' => 400));
         }
         $new_stock = max(0, $current_stock - $quantity);
     } elseif ($type === 'adjust') {
@@ -396,11 +558,14 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
     }
 
     if (!empty($product['is_kit']) && $type === 'out') {
-        $components = $wpdb->get_results($wpdb->prepare(
-            "SELECT kc.component_id, kc.quantity, p.name, p.stock FROM {$wpdb->prefix}kit_components kc " .
-            "JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d",
-            $product_id
-        ), ARRAY_A);
+        $components = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT kc.component_id, kc.quantity, p.name, p.stock FROM {$wpdb->prefix}kit_components kc " .
+                "JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d",
+                $product_id
+            ),
+            ARRAY_A
+        );
 
         foreach ($components as $component) {
             $required = intval($component['quantity']) * $quantity;
@@ -408,7 +573,7 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
             if ($required > $available) {
                 return new WP_Error(
                     'insufficient_component_stock',
-                    sprintf('Stock insuffisant pour le composant %s.', $component['name']),
+                    sprintf(__('Stock insuffisant pour le composant %s.', 'sempa'), $component['name']),
                     array('status' => 400)
                 );
             }
@@ -416,20 +581,22 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
 
         foreach ($components as $component) {
             $required = intval($component['quantity']) * $quantity;
-            $wpdb->query($wpdb->prepare(
-                "UPDATE {$wpdb->prefix}products SET stock = GREATEST(stock - %d, 0) WHERE id = %d",
-                $required,
-                intval($component['component_id'])
-            ));
+            $wpdb->query(
+                $wpdb->prepare(
+                    "UPDATE {$wpdb->prefix}products SET stock = GREATEST(stock - %d, 0) WHERE id = %d",
+                    $required,
+                    intval($component['component_id'])
+                )
+            );
             $component_logs[] = sprintf('%s (-%d)', $component['name'], $required);
         }
     }
 
     $wpdb->update(
         "{$wpdb->prefix}products",
-        array('stock' => $new_stock),
+        array('stock' => $new_stock, 'lastUpdated' => current_time('mysql')),
         array('id' => $product_id),
-        array('%d'),
+        array('%d', '%s'),
         array('%d')
     );
 
@@ -441,29 +608,29 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
             'type' => $type,
             'quantity' => $quantity,
             'reason' => $reason,
-            'date' => current_time('mysql')
+            'date' => current_time('mysql'),
         ),
         array('%d', '%s', '%s', '%d', '%s', '%s')
     );
 
-    if ($movement_inserted === false) {
-        return new WP_Error('db_error', 'Impossible de créer le mouvement.', array('status' => 500));
+    if ($movement_inserted === false || !empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error ?: __('Impossible de créer le mouvement.', 'sempa'), array('status' => 500));
     }
 
     $current_user = wp_get_current_user();
     $log_action = '';
     switch ($type) {
         case 'in':
-            $log_action = sprintf("Entrée de stock : +%d (stock actuel : %d). Raison : %s", $quantity, $new_stock, $reason);
+            $log_action = sprintf(__('Entrée de stock : +%d (stock actuel : %d). Raison : %s', 'sempa'), $quantity, $new_stock, $reason);
             break;
         case 'out':
-            $log_action = sprintf("Sortie de stock : -%d (stock actuel : %d). Raison : %s", $quantity, $new_stock, $reason);
+            $log_action = sprintf(__('Sortie de stock : -%d (stock actuel : %d). Raison : %s', 'sempa'), $quantity, $new_stock, $reason);
             if ($component_logs) {
-                $log_action .= ' | Composants ajustés : ' . implode(', ', $component_logs);
+                $log_action .= ' | ' . __('Composants ajustés : ', 'sempa') . implode(', ', $component_logs);
             }
             break;
         case 'adjust':
-            $log_action = sprintf("Stock ajusté à %d (ancien stock : %d). Raison : %s", $new_stock, $current_stock, $reason);
+            $log_action = sprintf(__('Stock ajusté à %d (ancien stock : %d). Raison : %s', 'sempa'), $new_stock, $current_stock, $reason);
             break;
     }
 
@@ -473,44 +640,73 @@ function sempa_create_movement_callback(WP_REST_Request $request) {
             'product_id' => $product_id,
             'user_name' => $current_user->display_name,
             'action' => $log_action,
-            'timestamp' => current_time('mysql')
+            'timestamp' => current_time('mysql'),
         ),
         array('%d', '%s', '%s', '%s')
     );
 
     $updated_product = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}products WHERE id = %d", $product_id), ARRAY_A);
+    if (!empty($updated_product['is_kit'])) {
+        $updated_product['components'] = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT p.id, p.name, p.reference, kc.quantity FROM {$wpdb->prefix}kit_components kc " .
+                "JOIN {$wpdb->prefix}products p ON p.id = kc.component_id WHERE kc.kit_id = %d",
+                $product_id
+            ),
+            ARRAY_A
+        );
+    }
 
-    return new WP_REST_Response(array(
+    return rest_ensure_response(array(
         'status' => 'success',
-        'product' => $updated_product,
-    ), 201);
+        'product' => sempa_normalize_product($updated_product),
+    ));
 }
 
 function sempa_get_categories_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}product_categories ORDER BY name ASC");
-    return new WP_REST_Response($categories, 200);
+    global $wpdb;
+    $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}product_categories ORDER BY name ASC", ARRAY_A);
+
+    return rest_ensure_response($categories);
 }
 
 function sempa_create_category_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $data = $request->get_json_params(); 
-    $name = sanitize_text_field($data['name']); 
-    $slug = sanitize_title($name);
-    
-    if (empty($name)) { 
-        return new WP_Error('bad_request', 'Le nom de la catégorie est obligatoire.', array('status' => 400)); 
+    global $wpdb;
+    $data = $request->get_json_params();
+    $name = sanitize_text_field($data['name'] ?? '');
+
+    if ($name === '') {
+        return new WP_Error('bad_request', __('Le nom de la catégorie est obligatoire.', 'sempa'), array('status' => 400));
     }
-    
-    $wpdb->insert("{$wpdb->prefix}product_categories", array('name' => $name, 'slug' => $slug));
-    return new WP_REST_Response(['status' => 'success', 'id' => $wpdb->insert_id], 201);
+
+    $slug = sanitize_title($name);
+    $wpdb->insert(
+        "{$wpdb->prefix}product_categories",
+        array('name' => $name, 'slug' => $slug),
+        array('%s', '%s')
+    );
+
+    if (!empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error, array('status' => 500));
+    }
+
+    return rest_ensure_response(array('status' => 'success', 'id' => $wpdb->insert_id));
 }
 
 function sempa_delete_category_callback(WP_REST_Request $request) {
-    global $wpdb; 
-    $id = $request->get_param('id');
+    global $wpdb;
+    $id = intval($request->get_param('id'));
+    if (!$id) {
+        return new WP_Error('bad_request', __('Identifiant manquant.', 'sempa'), array('status' => 400));
+    }
+
     $wpdb->delete("{$wpdb->prefix}product_categories", array('id' => $id));
-    return new WP_REST_Response(['status' => 'success'], 200);
+
+    if (!empty($wpdb->last_error)) {
+        return new WP_Error('db_error', $wpdb->last_error, array('status' => 500));
+    }
+
+    return rest_ensure_response(array('status' => 'success'));
 }
 // --- FIN : API DE GESTION DE STOCKS SEMPA ---
 


### PR DESCRIPTION
## Summary
- split the stock management REST routes into explicit collection/item endpoints with validation and hardened permission checks
- normalize product payloads, record history updates safely, and improve error handling across stock mutations
- update the stock management SPA to build relative API URLs, send credentials/nonces, and reuse the JSON helper for uploads

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e61b0172d8832fb6faf8f6d1a903dc